### PR TITLE
FIX: optimal time calculation when some algos don't have results.

### DIFF
--- a/source/output.h
+++ b/source/output.h
@@ -457,7 +457,7 @@ int outputHTML2(	double PRE_TIME[NumAlgo][NumPatt],
 		OPTIMAL[il] = 0.0;
 	    for(algo=0; algo<NumAlgo; algo++)
 			if(EXECUTE[algo]) {
-				if(OPTIMAL[il]==0.0 || OPTIMAL[il]>TIME[algo][il])  OPTIMAL[il]=TIME[algo][il];
+				if(OPTIMAL[il]==0.0 || (OPTIMAL[il]>TIME[algo][il] && TIME[algo][il] > 0.0))  OPTIMAL[il]=TIME[algo][il];
 			}
 	}
 


### PR DESCRIPTION
  * Existing code keeps setting optimal time back to zero if some
    algorithms don't have results.
  * Fix is to test that we only set optimal value if the time of the
    algorithm is greater than zero.

closes #9