### PR TITLE
FIX: QF algorithms not ANDing with preceding value to ensure phase alignment.

### DIFF
--- a/source/algos/qf33.c
+++ b/source/algos/qf33.c
@@ -67,7 +67,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf34.c
+++ b/source/algos/qf34.c
@@ -67,7 +67,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf36.c
+++ b/source/algos/qf36.c
@@ -67,7 +67,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf42.c
+++ b/source/algos/qf42.c
@@ -69,7 +69,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf43.c
+++ b/source/algos/qf43.c
@@ -69,7 +69,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf44.c
+++ b/source/algos/qf44.c
@@ -69,7 +69,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf62.c
+++ b/source/algos/qf62.c
@@ -73,7 +73,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf63.c
+++ b/source/algos/qf63.c
@@ -73,7 +73,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/output.h
+++ b/source/output.h
@@ -457,7 +457,7 @@ int outputHTML2(	double PRE_TIME[NumAlgo][NumPatt],
 		OPTIMAL[il] = 0.0;
 	    for(algo=0; algo<NumAlgo; algo++)
 			if(EXECUTE[algo]) {
-				if(OPTIMAL[il]==0.0 || OPTIMAL[il]>TIME[algo][il])  OPTIMAL[il]=TIME[algo][il];
+				if(OPTIMAL[il]==0.0 || (OPTIMAL[il]>TIME[algo][il] && TIME[algo][il] > 0.0))  OPTIMAL[il]=TIME[algo][il];
 			}
 	}
 


### PR DESCRIPTION
This PR fixes the QF algorithms that were not performing an & operation on the D value, to ensure that successive qgrams are aligned with the phase of the preceding qgram.  The QF algorithms for 2-qgrams were correct, but all the others did not do this.

closes https://github.com/smart-tool/smart/issues/7