### PR TITLE
Fix table output and graphs in HTML by setting MINLEN to 1.

### DIFF
--- a/source/algos/qf33.c
+++ b/source/algos/qf33.c
@@ -67,7 +67,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf34.c
+++ b/source/algos/qf34.c
@@ -67,7 +67,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf36.c
+++ b/source/algos/qf36.c
@@ -67,7 +67,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf42.c
+++ b/source/algos/qf42.c
@@ -69,7 +69,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf43.c
+++ b/source/algos/qf43.c
@@ -69,7 +69,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf44.c
+++ b/source/algos/qf44.c
@@ -69,7 +69,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf62.c
+++ b/source/algos/qf62.c
@@ -73,7 +73,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/algos/qf63.c
+++ b/source/algos/qf63.c
@@ -73,7 +73,7 @@ int search(unsigned char *x, int m, unsigned char *y, int n)
 				ch = (ch<<S) + y[i+2];
 				ch = (ch<<S) + y[i+1];
 				ch = (ch<<S) + y[i];
-				D = B[ch & mask];
+				D &= B[ch & mask];
 		      if(D == 0) continue;
 		      else goto more;
 			} 

--- a/source/smart.c
+++ b/source/smart.c
@@ -27,7 +27,7 @@
 #define MAXTIME		999.00
 
 /* DEFINITION OF VARIABLES */
-unsigned int MINLEN = 0, MAXLEN = 4200; //min length and max length of pattern size
+unsigned int MINLEN = 1, MAXLEN = 4200; //min length and max length of pattern size
 
 
 #include <stdlib.h>


### PR DESCRIPTION
The current HTML output displays columns with no values (stringlength = 0), and the graphs are broken and pop up messages saying there are negative values.

Setting the MINLEN to 1 fixes both these issues.