### PR TITLE
Fix buffer overflow in command.

### DIFF
--- a/source/compilesm.c
+++ b/source/compilesm.c
@@ -28,7 +28,7 @@
  */
 
 int main(int argc, char **argv) {
-	char filename[100], command[100], binary[100];
+	char filename[100], command[512], binary[100];
 	int i,j;
 	char gcc[100] = "gcc source/algos/";
 	char options[100] = " -O3 -msse4 -lm -o source/bin/"; 


### PR DESCRIPTION
   * gcc reports up to 400 chars can be written into 100 char buffer.
   * increase size to 512 to give a bit of headroom.