### PR TITLE
Initialise e_time and pre-time to zero.

### DIFF
--- a/source/smart.c
+++ b/source/smart.c
@@ -317,6 +317,7 @@ int run_setting(char *filename, key_t tkey, unsigned char* T, int n,
 			else printf("\b\b\b\b[%d%%]", perc);
 			fflush(stdout);
 
+            (*e_time) = (*pre_time) = 0.0;
         	occur = execute(algo,pkey,m,tkey,n,rkey,ekey,prekey,count,alpha);
 
 			if(!pre) (*e_time) += (*pre_time); 


### PR DESCRIPTION
  When no algorithms run for a pattern size (e.g. they all can't handle length of 2), the
  worst times are still calculated, but the e_time or pre_time may not be
  properly initialized.  If the uninitialized value is large, then the
  WORST times end up with this huge value.

  Fix is to set them both to zero before benchmarking.

  This issue was found when a result web page stopped responding.
  The line drawing algorithm was trying to find a scale against an absolutely
  astronomical number.  This had been written into the WORST results, as
  the uninitialized value happened to be really big (1E+170).