### PR TITLE
Capture running statistics for algorithms

### DIFF
--- a/results/js/Smart.TimeResultFormatting.js
+++ b/results/js/Smart.TimeResultFormatting.js
@@ -75,6 +75,14 @@ function showDivs(document, divClass, show) {
   }
 }
 
+function showDivsByName(document, divName, show) {
+    const divs = document.getElementsByName(divName);
+    const displayValue = show ? 'block' : 'none';
+    for (const counter in divs) {
+        divs[counter].style.display = displayValue;
+    }
+}
+
 function findChildWithClassNames(parent, namesOfClass) {
     const parentChildren = parent.children;
     for (let counter = 0; counter < parentChildren.length; counter++) {

--- a/results/style.css
+++ b/results/style.css
@@ -120,6 +120,14 @@ td{
     vertical-align:middle;
 }
 
+.statNames {
+	background-color: #666666;
+	font-size: 11px;
+	text-align:center;
+	color: #eeeeee;
+	vertical-align:middle;
+}
+
 .didascalia {
 	width: 70px;
 	float: left;
@@ -195,6 +203,55 @@ td{
 	vertical-align:middle;
     border-radius: 4px;
     color: #888888;
+}
+
+.search_stats {
+	padding: 2px;
+	width: 40px;
+	height: 15px;
+	font-size: 11px;
+	text-align:center;
+	border-radius: 8px;
+	margin-top:3px;
+	margin-bottom:3px;
+	color: #000000;
+	vertical-align:middle;
+}
+
+.search_stats_best {
+	padding: 2px;
+	background-color: Honeydew;
+	width: 40px;
+	height: 10px;
+	font-size: 10px;
+	text-align:center;
+	border-radius: 4px;
+	color: #333333;
+	vertical-align:middle;
+}
+
+.search_stats_worst {
+	padding: 2px;
+	background-color: LavenderBlush;
+	width: 60px;
+	height: 10px;
+	font-size: 10px;
+	text-align:center;
+	vertical-align:middle;
+	border-radius: 4px;
+	color: #333333;
+}
+
+.search_stats_none {
+	padding: 2px;
+	background-color: #ffffff;
+	width: 60px;
+	height: 10px;
+	font-size: 10px;
+	text-align:center;
+	vertical-align:middle;
+	border-radius: 4px;
+	color: #000000;
 }
 
 .main_container {

--- a/results/style.css
+++ b/results/style.css
@@ -207,7 +207,7 @@ td{
 
 .search_stats {
 	padding: 2px;
-	width: 40px;
+	width: 60px;
 	height: 15px;
 	font-size: 11px;
 	text-align:center;
@@ -221,7 +221,7 @@ td{
 .search_stats_best {
 	padding: 2px;
 	background-color: Honeydew;
-	width: 40px;
+	width: 60px;
 	height: 10px;
 	font-size: 10px;
 	text-align:center;
@@ -246,7 +246,7 @@ td{
 	padding: 2px;
 	background-color: #ffffff;
 	width: 60px;
-	height: 10px;
+	height: 15px;
 	font-size: 10px;
 	text-align:center;
 	vertical-align:middle;

--- a/source/algos/hash5.c
+++ b/source/algos/hash5.c
@@ -22,7 +22,9 @@
  */
 
 #include "include/define.h"
-#include "include/main.h"
+#include "include/mainstats.h" // defines the search interface for time and statistics.
+#include "include/shiftstats.h"  // implements the standard set of shift-table algorithm statistic names.
+
 #define RANK5 5
 
 int search(unsigned char *x, int m, unsigned char *y, int n) {
@@ -89,4 +91,86 @@ int search(unsigned char *x, int m, unsigned char *y, int n) {
       	return count;
       }
    }
+}
+
+
+struct searchInfo searchStats(unsigned char *x, int m, unsigned char *y, int n) {
+    int count,i, j,sh, shift[WSIZE], sh1, mMinus1, mMinus4;
+    unsigned int h;
+    if(m<5) return NO_ALGO_RESULTS;
+
+    /* Preprocessing */
+    count = 0;
+    mMinus1 = m-1;
+    mMinus4 = m-4;
+    for (i = 0; i < WSIZE; ++i)
+        shift[i] = mMinus4;
+
+    h = x[0];
+    h = ((h<<1) + x[1]);
+    h = ((h<<1) + x[2]);
+    h = ((h<<1) + x[3]);
+    h = ((h<<1) + x[4]);
+    shift[h%WSIZE] = m-RANK5;
+    for (i=RANK5; i < mMinus1; ++i) {
+        h = x[i-4];
+        h = ((h<<1) + x[i-3]);
+        h = ((h<<1) + x[i-2]);
+        h = ((h<<1) + x[i-1]);
+        h = ((h<<1) + x[i]);
+        shift[h%WSIZE] = mMinus1-i;
+    }
+    h = x[i-4];
+    h = ((h<<1) + x[i-3]);
+    h = ((h<<1) + x[i-2]);
+    h = ((h<<1) + x[i-1]);
+    h = ((h<<1) + x[i]);
+    sh1 = shift[h%WSIZE];
+    shift[h%WSIZE] = 0;
+    if(sh1==0) sh1=1;
+
+    /* Basic search info */
+    struct searchInfo results = {0};
+    initStats(&results, n, WSIZE, sizeof(int));
+
+    /* Table stats */
+    sumTable(0, &results, shift, WSIZE);
+
+    i = mMinus1;
+    memcpy(y+n, x, m);
+    while (1) {
+        results.mainLoopCount++;
+
+        sh = 1;
+        while (sh != 0) {
+            h = y[i-4];
+            h = ((h<<1) + y[i-3]);
+            h = ((h<<1) + y[i-2]);
+            h = ((h<<1) + y[i-1]);
+            h = ((h<<1) + y[i]);
+            results.textBytesRead += 5;
+
+            sh = shift[h%WSIZE];
+            results.indexLookupCount++;
+
+            i+=sh;
+            results.numShifts++;
+        }
+        if (i < n) {
+            results.validationCount++;
+            j=0;
+            while(++results.textBytesRead && ++results.validationBytesRead && j<m && x[j]==y[i-mMinus1+j]) {
+                j++;
+            }
+            if (j>=m) {
+                results.matchCount++;
+            }
+            i+=sh1;
+            results.validationShifts += sh1;
+            results.numShifts++;
+        }
+        else {
+            return results;
+        }
+    }
 }

--- a/source/algos/include/bitstats.h
+++ b/source/algos/include/bitstats.h
@@ -9,7 +9,7 @@
 
 struct algoValueNames getAlgoValueNames() {
     struct algoValueNames names = {0};
-    setAlgoValueName(&names, 0, "bitcount", "Count of bits set in index");
+    setAlgoValueName(&names, 0, "bits", "Count of bits set in index");
     setAlgoValueName(&names, 1, "empty", "Count of empty index entries");
     return names;
 }

--- a/source/algos/include/bitstats.h
+++ b/source/algos/include/bitstats.h
@@ -1,6 +1,7 @@
 //
 // Created by matt on 05/05/2022.
 //
+
 #include "../../searchinfo.h"
 
 #ifndef SMART_BITSTATS_H

--- a/source/algos/include/bitstats.h
+++ b/source/algos/include/bitstats.h
@@ -1,0 +1,16 @@
+//
+// Created by matt on 05/05/2022.
+//
+#include "../../searchinfo.h"
+
+#ifndef SMART_BITSTATS_H
+#define SMART_BITSTATS_H
+
+struct algoValueNames getAlgoValueNames() {
+    struct algoValueNames names = {0};
+    setAlgoValueName(&names, 0, "bitcount", "Count of bits set in index");
+    setAlgoValueName(&names, 1, "empty", "Count of empty index entries");
+    return names;
+}
+
+#endif //SMART_BITSTATS_H

--- a/source/algos/include/bitstats2.h
+++ b/source/algos/include/bitstats2.h
@@ -8,9 +8,9 @@
 
 struct algoValueNames getAlgoValueNames() {
     struct algoValueNames names = {0};
-    setAlgoValueName(&names, 0, "bitcount1", "Count of bits set in index1");
+    setAlgoValueName(&names, 0, "bits1", "Count of bits set in index1");
     setAlgoValueName(&names, 1, "empty1", "Count of empty index1 entries");
-    setAlgoValueName(&names, 2, "bitcount2", "Count of bits set in index2");
+    setAlgoValueName(&names, 2, "bits2", "Count of bits set in index2");
     setAlgoValueName(&names, 3, "empty2", "Count of empty index2 entries");
     return names;
 }

--- a/source/algos/include/bitstats2.h
+++ b/source/algos/include/bitstats2.h
@@ -1,0 +1,18 @@
+//
+// Created by matt on 26/05/2022.
+//
+#include "../../searchinfo.h"
+
+#ifndef SMARTC_BITSTATS2_H
+#define SMARTC_BITSTATS2_H
+
+struct algoValueNames getAlgoValueNames() {
+    struct algoValueNames names = {0};
+    setAlgoValueName(&names, 0, "bitcount1", "Count of bits set in index1");
+    setAlgoValueName(&names, 1, "empty1", "Count of empty index1 entries");
+    setAlgoValueName(&names, 2, "bitcount2", "Count of bits set in index2");
+    setAlgoValueName(&names, 3, "empty2", "Count of empty index2 entries");
+    return names;
+}
+
+#endif //SMARTC_BITSTATS2_H

--- a/source/algos/include/main.h
+++ b/source/algos/include/main.h
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
 	_timer = (TIMER*) malloc (sizeof(TIMER));
     unsigned char *p, *t;
 	int m, n;
-	if(!strcmp("shared", argv[1])) {
+    if(argc==2 && !strcmp("-stats", argv[1])) {
+        return -4; // stats not supported.
+    }
+    if(!strcmp("shared", argv[1])) {
 		if(argc < 7) {
 			printf("error in input parameter\nfive parameters needed when used with shared memory\n");
 			return 1;

--- a/source/algos/include/mainstats.h
+++ b/source/algos/include/mainstats.h
@@ -1,0 +1,347 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ */
+
+#include "timer.h"
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../searchinfo.h"
+
+#define BEGIN_PREPROCESSING	{timer_start(_timer);start = clock();}
+#define BEGIN_SEARCHING		{timer_start(_timer);start = clock();}
+#define END_PREPROCESSING	{timer_stop(_timer);end = clock();(*pre_time) = timer_elapsed(_timer)*1000;}
+#define END_SEARCHING		{timer_stop(_timer);end = clock();(*run_time) = timer_elapsed(_timer)*1000;}
+
+/* global variables used for computing preprocessing and searching times */
+double *run_time, 		// searching time
+*pre_time;	// preprocessing time
+clock_t start, end;
+TIMER * _timer;
+
+
+/*********************************************************************************************************
+ * Main interface to implement in each search algorithm supporting runtime statistics.
+ */
+
+/*
+ * The search function which is timed.
+ */
+int search(unsigned char* p, int m, unsigned char* t, int n);
+
+/*
+ * An instrumented version of the search function that is not timed, but returns running statistics.
+ * Take a copy of the search method and modify it, taking out the timing macros, and
+ * recording the runtime statistics of the algorithm instead, returning searchInfo rather than int.
+ */
+struct searchInfo searchStats(unsigned char* p, int m, unsigned char* t, int n);
+
+/*
+ * A function that returns any special algorithm statistic names used in the searchStats function.
+ * If only the standard stats are returned, all the names should be empty.
+ * If any special stats are defined, return names for those statistics here.
+ * A standard set of algo value stat names for many bit oriented algorithms is provided in "bitstats.h",
+ * (a count of empty table slots and a count of total bits set in the table), so if you need to provide
+ * those stats, just include the header - you don't need to implement this method.
+ */
+struct algoValueNames getAlgoValueNames();
+
+
+/*********************************************************************************************************
+ * Convenience function for returning how many bytes were read in the text against a pattern at some position.
+ * Many algorithms use memcmp() for a fast pattern comparison, but this does not give us the number of bytes
+ * scanned if there was no match, which is a stat we collect (validationBytesRead).
+ * Replace calls to memcmp() in the searchStats() method with matchLength,
+ * and test that the bytes read == m to record an occurrence.
+ */
+int matchLength(unsigned char *p, int m, unsigned char *t, int n, int pos) {
+    if (pos + m > n) {
+        return 0;
+    }
+    for (int i = 0; i < m; i++) {
+        if (p[i] != t[pos + i]) {
+            return i + 1; // at pos zero, even if we don't have a match, we have read one byte.
+        }
+    }
+    return m;
+}
+
+
+/*********************************************************************************************************
+ * Convenience functions to calculate various table statistics.
+ */
+
+/*
+ * Counts the bits set in an unsigned integer.
+ * This is Brian Kernighan's method for counting bits,
+ * from https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
+ */
+int countBitsSet(unsigned int value) {
+    unsigned int c; // c accumulates the total bits set in v
+    for (c = 0; value; c++)
+    {
+        value &= value - 1; // clear the least significant bit set
+    }
+    return c;
+}
+
+/*
+ * Counts the number of empty table slots and the total bits set in a table of integers,
+ * and places the results in algorithm statistics with the given indices.
+ */
+void countEmptySlotsAndBitsSet(int bitValueIndex, int emptyValueIndex, struct searchInfo * searchInfo, int *table, int numEntries) {
+    for (int i = 0; i < numEntries; i++) {
+        if (table[i]) {
+            searchInfo->algoValues[bitValueIndex] += countBitsSet(table[i]);
+        } else {
+            searchInfo->algoValues[emptyValueIndex] += 1;
+        }
+    }
+}
+
+/*
+ * Counts the number of empty table slots and the total bits set in a table of unsigned integers,
+ * and places the results in algorithm statistics with the given indices.
+ */
+void countEmptySlotsAndBitsSetU(int bitValueIndex, int emptyValueIndex, struct searchInfo * searchInfo, unsigned int *table, int numEntries) {
+    for (int i = 0; i < numEntries; i++) {
+        if (table[i]) {
+            searchInfo->algoValues[bitValueIndex] += countBitsSet(table[i]);
+        } else {
+            searchInfo->algoValues[emptyValueIndex] += 1;
+        }
+    }
+}
+
+/*
+ * Counts the number of empty table slots and the total bits set in a table of long,
+ * and places the results in algorithm statistics with the given indices.
+ */
+void countEmptySlotsAndBitsSetL(int bitValueIndex, int emptyValueIndex, struct searchInfo * searchInfo, long *table, int numEntries) {
+    for (int i = 0; i < numEntries; i++) {
+        if (table[i]) {
+            searchInfo->algoValues[bitValueIndex] += countBitsSet(table[i]);
+        } else {
+            searchInfo->algoValues[emptyValueIndex] += 1;
+        }
+    }
+}
+
+/*
+ * Counts the number of empty table slots and the total bits set in a table of unsigned longs,
+ * and places the results in algorithm statistics with the given indices.
+ */
+void countEmptySlotsAndBitsSetUL(int bitValueIndex, int emptyValueIndex, struct searchInfo * searchInfo, unsigned long *table, int numEntries) {
+    for (int i = 0; i < numEntries; i++) {
+        if (table[i]) {
+            searchInfo->algoValues[bitValueIndex] += countBitsSet(table[i]);
+        } else {
+            searchInfo->algoValues[emptyValueIndex] += 1;
+        }
+    }
+}
+
+/*
+ * Counts the number of empty table slots and the total bits set in a table of char,
+ * and places the results in algorithm statistics with the given indices.
+ */
+void countEmptySlotsAndBitsSetC(int bitValueIndex, int emptyValueIndex, struct searchInfo * searchInfo, char *table, int numEntries) {
+    for (int i = 0; i < numEntries; i++) {
+        if (table[i]) {
+            searchInfo->algoValues[bitValueIndex] += countBitsSet(table[i]);
+        } else {
+            searchInfo->algoValues[emptyValueIndex] += 1;
+        }
+    }
+}
+
+/*
+ * Adds up all the integers in a table of integers, and places the result in an algorithm statistic with the given index.
+ */
+void sumTable(int sumValueIndex, struct searchInfo* searchInfo, int *table, int numEntries) {
+    int sum = 0;
+    for (int i = 0; i < numEntries; i++) {
+        sum += table[i];
+    }
+    searchInfo->algoValues[sumValueIndex] = sum;
+}
+
+
+/*********************************************************************************************************
+ * Main
+ */
+
+int main(int argc, char *argv[])
+{
+    _timer = (TIMER*) malloc (sizeof(TIMER));
+    unsigned char *p, *t;
+    int m, n;
+    if(argc==2 && !strcmp("-stats", argv[1])) {
+        return 0;
+    }
+    if(!strcmp("-statnames", argv[1])) { // invoke with just -statnames to print a list of the names of any algo stats provided.
+        struct algoValueNames names = getAlgoValueNames();
+        printAlgoValueNames("%s\n", &names);
+    } else  if(!strcmp("shared", argv[1])) {
+        if (argc == 4 && !strcmp("-statnames", argv[2])) { //{progname} shared -statnames {shared mem for algo names struct}
+            struct algoValueNames *algoNames;
+            int snshmid;
+            key_t snkey = atoi(argv[3]);
+            if ((snshmid = shmget(snkey, sizeof(struct algoValueNames), 0666)) < 0) {
+                perror("shmget");
+                return 1;
+            }
+            /* Now we attach the segment to our data space. */
+            if ((algoNames = shmat(snshmid, NULL, 0)) == (struct algoValueNames *) -1) {
+                perror("shmat");
+                return 1;
+            }
+            struct algoValueNames names = getAlgoValueNames();
+           // printf("\nGot names:\n");
+          //  printAlgoValueNames("%s\n", &names);
+
+            (*algoNames) = names;
+            return 0;
+        }
+        if(argc != 8 && argc != 9) {
+            printf("error in input parameter:\nfour, six or seven parameters needed when used with shared memory\n");
+            return 1;
+        }
+        int pshmid, tshmid, eshmid, preshmid, sishmid;
+        /* Locate the pattern. */
+        key_t pkey = atoi(argv[2]); //segment name for the pattern
+        m = atoi(argv[3]); //segment size for the pattern
+        if ((pshmid = shmget(pkey, m, 0666)) < 0) {
+            perror("shmget");
+            return 1;
+        }
+        /* Now we attach the segment to our data space. */
+        if ((p = shmat(pshmid, NULL, 0)) == (unsigned char *) -1) {
+            perror("shmat");
+            return 1;
+        }
+
+        /* Locate the text. */
+        key_t tkey = atoi(argv[4]); //segment name for the text
+        n = atoi(argv[5]); //segment size for the text
+        if ((tshmid = shmget(tkey, n, 0666)) < 0) {
+            perror("shmget");
+            return 1;
+        }
+        /* Now we attach the segment to our data space. */
+        if ((t = shmat(tshmid, NULL, 0)) == (unsigned char *) -1) {
+            perror("shmat");
+            return 1;
+        }
+
+        /* 8 arguments are for statistics: {progname}, 'shared', pattern, pattern_length, text, text_length, '-stats', searchInfo */
+        if (argc == 8) {
+            if (strcmp("-stats", argv[6])) {
+                printf("error in input parameter:\nthe sixth parameter should be '-stats' with seven parameters.\n");
+                return 1;
+            }
+
+            struct searchInfo *searchInfo;
+            key_t skey = atoi(argv[7]); // segment name for search info.
+            if ((sishmid = shmget(skey, sizeof(struct searchInfo), 0666)) < 0) {
+                perror("shmget");
+                return 1;
+            }
+            /* Now we attach the segment to our search info variable space. */
+            if ((searchInfo = shmat(sishmid, NULL, 0)) == (struct searchInfo *) -1) {
+                perror("shmat");
+                return 1;
+            }
+
+            (*searchInfo) = searchStats(p, m, t, n);
+            return 0;
+
+        } else { // 9 arguments are for benchmarking: {progname}, 'shared', pattern, pattern_length, text, text_length, result, search time, pre processing time.
+            /* Locate the running time variable */
+            key_t ekey = atoi(argv[7]); //segment name for the running time
+            if ((eshmid = shmget(ekey, 8, 0666)) < 0) {
+                perror("shmget");
+                return 1;
+            }
+            /* Now we attach the segment to our time variable space. */
+            if ((run_time = shmat(eshmid, NULL, 0)) == (double *) -1) {
+                perror("shmat");
+                return 1;
+            }
+
+            /* Locate the preprocessing running time variable */
+            key_t prekey = atoi(argv[8]); //segment name for the preprocessing running time
+            if ((preshmid = shmget(prekey, 8, 0666)) < 0) {
+                perror("shmget");
+                return 1;
+            }
+            /* Now we attach the segment to our time variable space. */
+            if ((pre_time = shmat(preshmid, NULL, 0)) == (double *) -1) {
+                perror("shmat");
+                return 1;
+            }
+
+            //timer_start(_timer);
+            //start = clock();
+            int count = search(p,m,t,n);
+            //timer_stop(_timer);
+            //end = clock();
+            //(*run_time) = timer_elapsed(_timer)*1000;
+
+            int rshmid, *result;
+            key_t rkey = atoi(argv[6]); //segment name for the occurrences
+            // Locate the int value.
+            if ((rshmid = shmget(rkey, 4, 0666)) < 0) {
+                perror("shmget");
+                return 1;
+            }
+            // Now we attach the segment to our data space.
+            if ((result = shmat(rshmid, NULL, 0)) == (int *) -1) {
+                perror("shmat");
+                return 1;
+            }
+            *result = count;
+            return 0;
+        }
+    }
+    else {
+        if(argc < 5) {
+            printf("error in input parameter\nfour parameters needed in standard mode\n");
+            return 1;
+        }
+        p = (unsigned char*) argv[1];
+        m = atoi(argv[2]);
+        t = (unsigned char*) argv[3];
+        n = atoi(argv[4]);
+        if (argc == 6 && !strcmp("-stats", argv[5])) {
+            const struct searchInfo searchInfo = searchStats(p, m, t, n);
+            const struct algoValueNames names = getAlgoValueNames();
+            printSearchInfo("%-32s\t%d\n", &searchInfo, &names);
+        } else {
+            int occ = search(p, m, t, n);
+            printf("found %d occurrences\n", occ);
+            return 0;
+        }
+    }
+}
+
+
+

--- a/source/algos/include/shiftstats.h
+++ b/source/algos/include/shiftstats.h
@@ -1,0 +1,16 @@
+//
+// Created by matt on 09/05/2022.
+//
+
+#include "../../searchinfo.h"
+
+#ifndef SMART_SHIFTSTATS_H
+#define SMART_SHIFTSTATS_H
+
+struct algoValueNames getAlgoValueNames() {
+    struct algoValueNames names = {0};
+    setAlgoValueName(&names, 0, "shiftsum", "Sum of shifts in the table");
+    return names;
+}
+
+#endif //SMART_SHIFTSTATS_H

--- a/source/output.h
+++ b/source/output.h
@@ -227,6 +227,7 @@ void outputAlgoStats(FILE *fp, int algo, int maxAlgoNameLen, int maxAlgoStatName
     outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, TEXT_LENGTH, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
     outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, SEARCH_INDEX_BYTES, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
     outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, SEARCH_INDEX_ENTRIES, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, SEARCH_INDEX2_ENTRIES, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
     outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, MAIN_LOOP_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
     outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, NUM_SHIFTS, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
     outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, INDEX_LOOKUP_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
@@ -638,6 +639,7 @@ void printSTATS(struct searchInfo AVERAGE_INFO[NumAlgo][NumPatt],
     printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, TEXT_LENGTH, fp);
     printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, SEARCH_INDEX_BYTES, fp);
     printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, SEARCH_INDEX_ENTRIES, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, SEARCH_INDEX2_ENTRIES, fp);
     printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, MAIN_LOOP_COUNT, fp);
     printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, NUM_SHIFTS, fp);
     printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, INDEX_LOOKUP_COUNT, fp);

--- a/source/output.h
+++ b/source/output.h
@@ -16,6 +16,11 @@
  * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
  * download the tool at: http://www.dmi.unict.it/~faro/smart/
  */
+#include "searchinfo.h"
+
+#define STAT_NAME_COLUMN_SIZE 20
+#define STAT_TYPE_COLUMN_SIZE 6
+#define STAT_VALUE_COLUMN_SIZE 9
 
 char colors[100][8];
 int num_colors = 100;
@@ -112,6 +117,12 @@ int outputPHP(double TIME[NumAlgo][NumPatt], double BEST[NumAlgo][NumPatt], doub
 	return 1;
 }
 
+void outputPaddedAlgoName(FILE *fp, char *algoName) {
+    fprintf(fp, "%s", str2upper(algoName));
+    size_t length = strlen(algoName);
+    for (int i = 0; i < 20 - length; i++) fprintf(fp, " ");
+}
+
 
 int outputTXT(double TIME[NumAlgo][NumPatt], int alpha, char *filename, char *expcode, char *time_format) {
   	int  i, il, algo;
@@ -148,6 +159,155 @@ int outputTXT(double TIME[NumAlgo][NumPatt], int alpha, char *filename, char *ex
 
 
 	return 1;
+}
+
+void outputStatRow(FILE *fp, int algo, int maxAlgoName, int maxAlgoStatNameLen, enum searchInfoStats statType, int algoStatIndex, char *resultType,
+                   struct searchInfo INFO[NumAlgo][NumPatt],
+                   struct algoValueNames ALGO_STAT_NAMES[NumAlgo]) {
+    fprintf(fp, "%-*s", maxAlgoName, str2upper(ALGO_NAME[algo]));
+    const struct algoValueNames *names = &(ALGO_STAT_NAMES[algo]);
+    const char * longName = names->longName[algoStatIndex];
+    const char *statName = statType == ALGO_VALUES ? longName[0] != '\0' ? longName : names->shortName[algoStatIndex] : getStatName(statType);
+    fprintf(fp, "\t%-*s", maxAlgoStatNameLen, statName);
+    fprintf(fp, "\t%-*s", STAT_TYPE_COLUMN_SIZE, resultType);
+    char statValue[32];
+    for(int il=0; il<NumPatt; il++)	if(PATT_SIZE[il]>=MINLEN && PATT_SIZE[il]<=MAXLEN) {
+        struct searchInfo *info = &(INFO[algo][il]);
+        if (info->patternLength > 0) {
+            long value = statType == ALGO_VALUES ? info->algoValues[algoStatIndex] : getStatValue(statType, info);
+            sprintf(statValue, "%ld", value);
+            fprintf(fp, "\t%*s", STAT_VALUE_COLUMN_SIZE, statValue);
+        } else {
+            fprintf(fp, "\t%*s", STAT_VALUE_COLUMN_SIZE, "-");
+        }
+    }
+    fprintf(fp, "\n");
+}
+
+void outputTimeStatRow(FILE *fp, int algo, int maxAlgoName, int maxAlgoStatNameLen, char *resultType, double TIME[NumAlgo][NumPatt]) {
+    fprintf(fp, "%-*s", maxAlgoName, str2upper(ALGO_NAME[algo]));
+    fprintf(fp, "%-*s", maxAlgoStatNameLen, "Running time");
+    fprintf(fp, "%-*s", STAT_TYPE_COLUMN_SIZE, resultType);
+    char statValue[32];
+    for(int il=0; il<NumPatt; il++)	if(PATT_SIZE[il]>=MINLEN && PATT_SIZE[il]<=MAXLEN) {
+        double time = TIME[NumAlgo][NumPatt];
+        if (time > 0.0) {
+            sprintf(statValue, "%.2f", time);
+            fprintf(fp, "\t%*s", STAT_VALUE_COLUMN_SIZE, statValue);
+        } else {
+            fprintf(fp, "\t%*s", STAT_VALUE_COLUMN_SIZE, "-");
+        }
+    }
+    fprintf(fp, "\n");
+}
+
+void outputTimeStatRows(FILE *fp, int algo, int maxAlgoName, int maxAlgoStatNameLen,
+                        double MEAN_TIME[NumAlgo][NumPatt], double BEST_TIME[NumAlgo][NumPatt], double WORST_TIME[NumAlgo][NumPatt]) {
+    outputTimeStatRow(fp, algo, maxAlgoName, maxAlgoStatNameLen, "Best", BEST_TIME);
+    outputTimeStatRow(fp, algo, maxAlgoName, maxAlgoStatNameLen, "Mean", MEAN_TIME);
+    outputTimeStatRow(fp, algo, maxAlgoName, maxAlgoStatNameLen, "Best", WORST_TIME);
+}
+
+void outputStatRows(FILE *fp, int algo, int maxAlgoName, int maxAlgoStatNameLen, enum searchInfoStats statType, int algoStatIndex,
+                    struct searchInfo AVG[NumAlgo][NumPatt],
+                    struct searchInfo BEST[NumAlgo][NumPatt],
+                    struct searchInfo WORST[NumAlgo][NumPatt],
+                    struct algoValueNames ALGO_STAT_NAMES[NumAlgo]) {
+    outputStatRow(fp, algo, maxAlgoName, maxAlgoStatNameLen, statType, algoStatIndex, "Best", BEST, ALGO_STAT_NAMES);
+    outputStatRow(fp, algo, maxAlgoName, maxAlgoStatNameLen, statType, algoStatIndex, "Mean", AVG, ALGO_STAT_NAMES);
+    outputStatRow(fp, algo, maxAlgoName, maxAlgoStatNameLen, statType, algoStatIndex, "Worst", WORST, ALGO_STAT_NAMES);
+}
+
+void outputAlgoStats(FILE *fp, int algo, int maxAlgoNameLen, int maxAlgoStatNameLen,
+                     struct searchInfo AVG[NumAlgo][NumPatt],
+                     struct searchInfo BEST[NumAlgo][NumPatt],
+                     struct searchInfo WORST[NumAlgo][NumPatt],
+                     struct algoValueNames ALGO_STAT_NAMES[NumAlgo]) {
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, TEXT_LENGTH, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, SEARCH_INDEX_BYTES, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, SEARCH_INDEX_ENTRIES, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, MAIN_LOOP_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, NUM_SHIFTS, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, INDEX_LOOKUP_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, FAST_PATH_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, SLOW_PATH_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, VALIDATION_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, MATCH_COUNT, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, FAST_PATH_SHIFTS, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, SLOW_PATH_SHIFTS, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, VALIDATION_SHIFTS, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, TEXT_BYTES_READ, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, VALIDATION_BYTES_READ, -1, AVG, BEST, WORST, ALGO_STAT_NAMES);
+    for (int valueIndex = 0; valueIndex < MAX_ALGO_VALUES; valueIndex++) {
+        struct algoValueNames * names = &(ALGO_STAT_NAMES[algo]);
+        if (names->shortName[valueIndex][0] != '\0') {
+            outputStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, ALGO_VALUES, valueIndex, AVG, BEST, WORST, ALGO_STAT_NAMES);
+        }
+    }
+}
+
+int outputStats(struct searchInfo AVG[NumAlgo][NumPatt], struct searchInfo BEST[NumAlgo][NumPatt], struct searchInfo WORST[NumAlgo][NumPatt],
+                double MEAN_TIME[NumAlgo][NumPatt], double BEST_TIME[NumAlgo][NumPatt], double WORST_TIME[NumAlgo][NumPatt],
+                char SUPPORTS_STATS[NumAlgo],
+                struct algoValueNames ALGO_STAT_NAMES[NumAlgo],
+                char *filename, char *expcode) {
+    int  i, il, algo;
+    FILE *fp;
+    char outname[256];
+    //printing results in txt format
+    strcpy(outname, "results/");
+    strcat(outname, expcode);
+    //mkdir(outname,S_IROTH);
+    strcat(outname, "/");
+    strcat(outname, filename);
+    strcat(outname, ".stats.txt");
+    printf("\tSaving stats data on %s/%s.stats.txt\n",expcode,filename);
+    if ( !(fp = fopen(outname,"w") ) ) {
+        printf("\tError in writing file %s/%s.stats.txt\n",expcode,filename);
+        return 0;
+    }
+
+    // Determine max width of algo names and algo stat names:
+    int maxAlgoNameLen = 0;
+    int maxAlgoStatNameLen = STAT_NAME_COLUMN_SIZE;
+    for (int algo = 0; algo < NumAlgo; algo++) if (EXECUTE[algo]) {
+        char *algoName = ALGO_NAME[algo];
+        size_t len = strlen(algoName);
+        if (len > maxAlgoNameLen) maxAlgoNameLen = len;
+        if (SUPPORTS_STATS[algo]) {
+            struct algoValueNames *names = &(ALGO_STAT_NAMES[algo]);
+            for (int i = 0; i < MAX_ALGO_VALUES; i++) {
+                const char * shortName = names->shortName[i];
+                const char * longName = names->longName[i];
+                size_t shortLen = strlen(shortName);
+                size_t longLen = strlen(longName);
+                if (shortLen > maxAlgoStatNameLen) maxAlgoStatNameLen = shortLen;
+                if (longLen > maxAlgoStatNameLen) maxAlgoStatNameLen = longLen;
+            }
+        }
+    }
+
+    // output table column headers
+    fprintf(fp, "%-*s", maxAlgoNameLen, "Algo");
+    fprintf(fp, "\t%-*s", maxAlgoStatNameLen, "Statistic");
+    fprintf(fp, "\t%-*s", STAT_TYPE_COLUMN_SIZE, "Type");
+    char value[32];
+    for(il=0; il<NumPatt; il++)	if(PATT_SIZE[il]>=MINLEN && PATT_SIZE[il]<=MAXLEN) {
+        sprintf(value, "%d", PATT_SIZE[il]);
+        fprintf(fp, "\t%-*s", STAT_VALUE_COLUMN_SIZE, value);
+    }
+    fprintf(fp,"\n");
+
+    // output rows:
+    for(algo = 0; algo < NumAlgo; algo++) {
+        if(EXECUTE[algo] && SUPPORTS_STATS[algo]) {
+            outputTimeStatRows(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, MEAN_TIME, BEST_TIME, WORST_TIME);
+            outputAlgoStats(fp, algo, maxAlgoNameLen, maxAlgoStatNameLen, AVG, BEST, WORST, ALGO_STAT_NAMES);
+        }
+    }
+
+    fclose(fp);
+    return 1;
 }
 
 int outputLatex(double TIME[NumAlgo][NumPatt], int alpha, char *filename, char *expcode, char* time_format) {
@@ -379,6 +539,86 @@ void printSTD(		double TIME[NumAlgo][NumPatt],
 	fprintf(fp,"}</script>");
 }
 
+void printPatternStatsRow(struct searchInfo AVG_INFO[NumAlgo][NumPatt],
+                          struct searchInfo BEST_INFO[NumAlgo][NumPatt],
+                          struct searchInfo WORST_INFO[NumAlgo][NumPatt],
+                          struct algoValueNames ALGO_STAT_NAMES[NumAlgo],
+                          int algo, int tableNo, enum searchInfoStats statType, FILE *fp) {
+
+    if (statType == ALGO_VALUES) {
+        struct algoValueNames *names = &(ALGO_STAT_NAMES[algo]);
+        for (int valueIndex = 0; valueIndex < MAX_ALGO_VALUES; valueIndex++) {
+            const char *shortName = names->shortName[valueIndex];
+            if (shortName[0] != '\0') {
+                const char *longName = names->longName[valueIndex];
+                const char *displayName = longName[0] != '\0' ? longName : shortName;
+                fprintf(fp, "<tr><td class=\"statNames\"><b>%s</b></td>\n", displayName);
+                for (int il = 0; il < NumPatt; il++)
+                    if (PATT_SIZE[il] >= MINLEN && PATT_SIZE[il] <= MAXLEN) {
+                        fprintf(fp, "<td><center>");
+                        struct searchInfo *avg = &(AVG_INFO[algo][il]);
+                        if (avg->patternLength > -1) {
+                            struct searchInfo *best = &(BEST_INFO[algo][il]);
+                            struct searchInfo *worst = &(WORST_INFO[algo][il]);
+                            fprintf(fp, "<div class=\"search_stats_best\" name=\"bestTable%d\" style=\"display:none\">%ld</div>", tableNo, best->algoValues[valueIndex]);
+                            fprintf(fp, "<div class=\"search_stats\">%ld</div>", avg->algoValues[valueIndex]);
+                            fprintf(fp, "<div class=\"search_stats_worst\" name=\"worstTable%d\" style=\"display:none\">%ld</div>", tableNo, worst->algoValues[valueIndex]);
+                        } else {
+                            fprintf(fp, "<div class=\"search_stats_best\" name=\"bestTable%d\" style=\"display:none\"></div>", tableNo);
+                            fprintf(fp, "<div class=\"search_stats_none\">-</div>");
+                            fprintf(fp, "<div class=\"search_stats_worst\" name=\"worstTable%d\" style=\"display:none\"></div>", tableNo);
+                        }
+                        fprintf(fp, "</center></td>");
+                    }
+                fprintf(fp, "</tr>\n");
+            }
+        }
+    } else {
+        fprintf(fp, "<tr><td class=\"statNames\"><b>%s</b></td>\n", getStatName(statType));
+        for (int il = 0; il < NumPatt; il++)
+            if (PATT_SIZE[il] >= MINLEN && PATT_SIZE[il] <= MAXLEN) {
+                fprintf(fp, "<td><center>");
+                struct searchInfo *avg = &(AVG_INFO[algo][il]);
+                if (avg->patternLength > -1) {
+                    struct searchInfo *best = &(BEST_INFO[algo][il]);
+                    struct searchInfo *worst = &(WORST_INFO[algo][il]);
+                    fprintf(fp, "<div class=\"search_stats_best\" name=\"bestTable%d\" style=\"display:none\">%ld</div>", tableNo, getStatValue(statType, best));
+                    fprintf(fp, "<div class=\"search_stats\">%ld</div>", getStatValue(statType, avg));
+                    fprintf(fp, "<div class=\"search_stats_worst\" name=\"worstTable%d\" style=\"display:none\">%ld</div>", tableNo, getStatValue(statType, worst));
+                }  else {
+                    fprintf(fp, "<div class=\"search_stats_best\" name=\"bestTable%d\" style=\"display:none\"></div>", tableNo);
+                    fprintf(fp, "<div class=\"search_stats_none\">-</div>");
+                    fprintf(fp, "<div class=\"search_stats_worst\" name=\"worstTable%d\" style=\"display:none\"></div>", tableNo);
+                }
+                fprintf(fp, "</center></td>");
+            }
+        fprintf(fp, "</tr>\n");
+    }
+}
+
+void printSTATS(struct searchInfo AVERAGE_INFO[NumAlgo][NumPatt],
+                struct searchInfo BEST_INFO[NumAlgo][NumPatt],
+                struct searchInfo WORST_INFO[NumAlgo][NumPatt],
+                struct algoValueNames ALGO_STAT_NAMES[NumAlgo],
+                int algo, int tableNo, int volte, char *expcode, FILE *fp) {
+    //printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, TEXT_LENGTH, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, SEARCH_INDEX_BYTES, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, SEARCH_INDEX_ENTRIES, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, MAIN_LOOP_COUNT, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, NUM_SHIFTS, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, INDEX_LOOKUP_COUNT, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, FAST_PATH_COUNT, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, SLOW_PATH_COUNT, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, VALIDATION_COUNT, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, MATCH_COUNT, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, FAST_PATH_SHIFTS, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, SLOW_PATH_SHIFTS, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, VALIDATION_SHIFTS, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, TEXT_BYTES_READ, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, VALIDATION_BYTES_READ, fp);
+    printPatternStatsRow(AVERAGE_INFO, BEST_INFO, WORST_INFO, ALGO_STAT_NAMES, algo, tableNo, ALGO_VALUES, fp);
+}
+
 void printMulti(	double TIME[NumAlgo][NumPatt],
 					FILE *fp, int w, int h, char *title, int code) {
 
@@ -444,8 +684,13 @@ int outputHTML2(	double PRE_TIME[NumAlgo][NumPatt],
 					double TIME[NumAlgo][NumPatt],
 					double BEST[NumAlgo][NumPatt],
 					double WORST[NumAlgo][NumPatt],
-					double STD[NumAlgo][NumPatt], 
-					int pre, int dif, int alpha, int n, int volte, char *filename, char *expcode, char *time_format) {
+					double STD[NumAlgo][NumPatt],
+					char SUPPORTS_STATS[NumAlgo],
+					struct searchInfo TOTAL_INFO[NumAlgo][NumPatt],
+					struct searchInfo BEST_INFO[NumAlgo][NumPatt],
+					struct searchInfo WORST_INFO[NumAlgo][NumPatt],
+                    struct algoValueNames ALGO_VALUE_NAMES[NumAlgo],
+					int pre, int dif, int alpha, int n, int volte, int stats, char *filename, char *expcode, char *time_format) {
   	int  i, il, algo;
    	FILE *fp;
 	char outname[100];
@@ -550,6 +795,7 @@ int outputHTML2(	double PRE_TIME[NumAlgo][NumPatt],
                "<div class=\"controlHorizontalFloat\">\n");
     fprintf(fp,"<input type=\"checkbox\" id=\"bestworst\" name=\"bestworst\" value=\"bestworst\" %s onclick=\"showDivs(document, 'dif', this.checked)\">\n", (dif? "checked" : ""));
     fprintf(fp,"<label for=\"bestworst\">Show best and worst running times</label></div><br></div><p>\n");
+
 	fprintf(fp,"<div class=\"chart_container\"><div class=\"chart_title\">Average Running Times</div>\n");
 	fprintf(fp,"<canvas class=\"exp_chart\" id=\"cvs\" width=\"780\" height=\"400\">[No canvas support]</canvas>");
     fprintf(fp,"<div style=\"padding-top:40px\">");
@@ -566,9 +812,33 @@ int outputHTML2(	double PRE_TIME[NumAlgo][NumPatt],
 	printMulti(	WORST, fp, 480, 250, "Worst Running Times", 2);
 	printMulti(	BEST, fp, 480, 250, "Best Running Times", 3);
 
+    int tableNo = 2;
    	for(algo=0; algo<NumAlgo; algo++) {
-		if(EXECUTE[algo])
-			printSTD(TIME, BEST, WORST, STD, algo, expcode, fp);
+		if(EXECUTE[algo]) {
+            printSTD(TIME, BEST, WORST, STD, algo, expcode, fp);
+            if (stats && SUPPORTS_STATS[algo]) {
+                fprintf(fp,"<div class=\"clearHorizontalFloat\"/>\n");
+                fprintf(fp,"<table class=\"exp_table\">\n");
+                fprintf(fp,"<tr><td class=\"length\"><b>%s</b</td>", ALGO_NAME[algo]);
+                for(int il=0; il<NumPatt; il++)	if(PATT_SIZE[il]>=MINLEN && PATT_SIZE[il]<=MAXLEN) {
+                        fprintf(fp,"<td class=\"length\">%d</td>",PATT_SIZE[il]);
+                    }
+                fprintf(fp,"</tr>");
+                printSTATS(TOTAL_INFO, BEST_INFO, WORST_INFO, ALGO_VALUE_NAMES, algo, tableNo, volte, expcode, fp);
+                fprintf(fp,"</table>\n");
+                fprintf(fp, "<div class=\"caption\"><b>Table %d.</b> Average running statistics of experimental tests n.%s for the <b>%s algorithm</b>. Each value is the mean of %d runs.<br>\n",tableNo, expcode, ALGO_NAME[algo], volte);
+                fprintf(fp, "If the appropriate checkboxes are selected, the stats of the run with the best running time are shown above the mean, and the stats with the worst running time below it. \n");
+                fprintf(fp, "<br>\n<div class=\"controlHorizontalFloat\">");
+                fprintf(fp, "<input type=\"checkbox\" id=\"bestTableCheck%d\" name=\"bestTableCheck%d\" onclick=\"showDivsByName(document, 'bestTable%d', this.checked)\">", tableNo, tableNo, tableNo);
+                fprintf(fp, "<label for=\"bestTableCheck%d\">Show stats for fastest run</label></div>\n", tableNo);
+                fprintf(fp, "<div class=\"controlHorizontalFloat\">");
+                fprintf(fp, "<input type=\"checkbox\" id=\"worstTableCheck%d\" name=\"worstTableCheck%d\" onclick=\"showDivsByName(document, 'worstTable%d', this.checked)\">", tableNo, tableNo, tableNo);
+                fprintf(fp, "<label for=\"worstTableCheck%d\">Show stats for slowest run</label></div>\n", tableNo);
+                fprintf(fp, "</div><br></div><p>\n");
+
+                tableNo++;
+            }
+        }
 	}
 
 	double dymax = 0.0;
@@ -624,9 +894,7 @@ int outputHTML2(	double PRE_TIME[NumAlgo][NumPatt],
 	}
 	fprintf(fp,"multiChart2(); multiChart3();\n");
 	fprintf(fp,"});</script>");
-    
-    
-	fprintf(fp,"</div>");
+ 	fprintf(fp,"</div>");
     fprintf(fp,"</body></html>");
    	fclose(fp);
 	return 1;

--- a/source/searchinfo.h
+++ b/source/searchinfo.h
@@ -179,7 +179,6 @@ struct searchInfo {
  * An enum for each of the different stat types.
  */
 enum searchInfoStats {
-    PATTERN_LENGTH,
     TEXT_LENGTH,
     SEARCH_INDEX_BYTES,
     SEARCH_INDEX_ENTRIES,
@@ -205,7 +204,6 @@ enum searchInfoStats {
  */
 const char* getStatName(enum searchInfoStats stat) {
     switch (stat) {
-        case PATTERN_LENGTH : return "Pattern length";
         case TEXT_LENGTH: return "Text length";
         case SEARCH_INDEX_BYTES: return "Search index bytes";
         case SEARCH_INDEX_ENTRIES: return "Search index entries";

--- a/source/searchinfo.h
+++ b/source/searchinfo.h
@@ -209,6 +209,7 @@ const char* getStatName(enum searchInfoStats stat) {
         case TEXT_LENGTH: return "Text length";
         case SEARCH_INDEX_BYTES: return "Search index bytes";
         case SEARCH_INDEX_ENTRIES: return "Search index entries";
+        case SEARCH_INDEX2_ENTRIES: return "Search index 2 entries";
         case MAIN_LOOP_COUNT: return "Main loop count";
         case TEXT_BYTES_READ: return "Text bytes read";
         case INDEX_LOOKUP_COUNT: return "Index lookup count";

--- a/source/searchinfo.h
+++ b/source/searchinfo.h
@@ -1,0 +1,395 @@
+//
+// Created by matt on 29/04/2022.
+//
+
+#ifndef SMART_SEARCHINFO_H
+#define SMART_SEARCHINFO_H
+
+#include <stdio.h>
+#include <string.h>
+
+#define MAX_ALGO_VALUES 8
+#define MAX_ALGO_VALUE_NAME_LEN 32
+
+/*
+ * A struct holding information about the operation of a search algorithm when searching a text.
+ */
+struct searchInfo {
+    /*
+     * The length of the pattern searched.
+     * If this is set to -1, then it indicates no results are available.
+     */
+    int patternLength;
+
+    /*
+     * The length of the text searched.
+     */
+    long textLength;
+
+    /*
+     * The number of bytes used by any search indices.
+     */
+    long searchIndexBytes;
+
+    /*
+     * THe number of entries available in the search indices.
+     */
+    long searchIndexEntries;
+
+    /*
+     * How many times the main search loop executes.
+     */
+    long mainLoopCount;
+
+    /*
+     * The total bytes read in the text by the search algorithm.
+     * This should include bytes read in both the searching and validation phases of the algorithm.
+     */
+    long textBytesRead;
+
+    /*
+     * The number of times a search index is accessed.
+     */
+    long indexLookupCount;
+
+    /*
+     * How many times the algorithm follows its fast path.
+     * If the fast path is taken repeatedly in a loop inside the main loop, each iteration of the fast path
+     * loop should be counted to better understand how much work is being done (rather than just counting
+     * that a fast path was entered once).
+     * Not all algorithms have a special fast path, but many do.
+     */
+    long fastPathCount;
+
+    /*
+     * The sum of shifts obtained when the algorithm operates in its fast path.
+     */
+    long fastPathShifts;
+
+    /*
+     * How many times the algorithm follows its slow path.
+     * If the slow path is taken repeatedly in a loop inside the main loop, each iteration of the slow path
+     * loop should be counted to better understand how much work is being done (rather than just counting
+     * that a slow path was entered once).
+     * Not all algorithms have a slow path, but ones with fast paths do.
+     */
+    long slowPathCount;
+
+    /*
+     * The sum of shifts obtained when the algorithm operates in its slow path.
+     */
+    long slowPathShifts;
+
+    /*
+     * The number of times a match validation occurs, regardless of whether a match is found.
+     */
+    long validationCount;
+
+    /*
+     * The number of bytes read during pattern validation.
+     * Note: a lot of algorithms use memcmp() to determine a match quickly, but this doesn't tell us how many
+     * bytes have been read.  In these cases, the memcmp() in the stats function should be replaced with a call
+     * to matchLength(), defined in mainstats.h.  This returns how many bytes were scanned when matching a pattern.
+     * Testing that the result equals the pattern length indicates a match.
+     */
+    long validationBytesRead;
+
+    /*
+     * The sum of shifts obtained after the algorithm has performed a validation.
+     */
+    long validationShifts;
+
+    /*
+     * The count of the number of times the algorithm shifts ahead (not the sum of the shifts themselves).
+     * When the number of shifts made is low, then the average length of the shifts obtained must be large,
+     * and vice versa.  Knowing the total shifts made is not interesting, as it always adds up to about the
+     * text length by the end of the search.  Knowing how many times a shift was made lets us understand
+     * the average shifts obtained in the run.
+     *
+     * Note: we only count a shift made when the algorithm makes use of it.
+     * If an algorithm during its main loop adds up a few different shifts to get the final shift, we only count
+     * them once.  It's not interesting that a final shift is determined over several calculations.
+     * It is interesting how many times the algorithm gets to actually use a shift.
+     */
+    long numShifts;
+
+    /*
+     * The number of occurrences found by the algorithm.
+     */
+    int matchCount;
+
+    /*
+     * Per algorithm statistic values.
+     * Set any of these values, and set a corresponding algorithm name in the getAlgoValueNames() function.
+     * If a name is set, then the statistic will be processed.
+     */
+    long algoValues[MAX_ALGO_VALUES];
+};
+
+/*
+ * An enum for each of the different stat types.
+ */
+enum searchInfoStats {
+    PATTERN_LENGTH,
+    TEXT_LENGTH,
+    SEARCH_INDEX_BYTES,
+    SEARCH_INDEX_ENTRIES,
+    MAIN_LOOP_COUNT,
+    TEXT_BYTES_READ,
+    INDEX_LOOKUP_COUNT,
+    FAST_PATH_COUNT,
+    FAST_PATH_SHIFTS,
+    SLOW_PATH_COUNT,
+    SLOW_PATH_SHIFTS,
+    VALIDATION_COUNT,
+    VALIDATION_BYTES_READ,
+    VALIDATION_SHIFTS,
+    NUM_SHIFTS,
+    MATCH_COUNT,
+    ALGO_VALUES
+};
+
+/*
+ * Returns the name of a stat given the enum for the stat.
+ * If you want the actual names of the per algorithm algo values, this must be obtained from the algoValueNames struct.
+ */
+const char* getStatName(enum searchInfoStats stat) {
+    switch (stat) {
+        case PATTERN_LENGTH : return "Pattern length";
+        case TEXT_LENGTH: return "Text length";
+        case SEARCH_INDEX_BYTES: return "Search index bytes";
+        case SEARCH_INDEX_ENTRIES: return "Search index entries";
+        case MAIN_LOOP_COUNT: return "Main loop count";
+        case TEXT_BYTES_READ: return "Text bytes read";
+        case INDEX_LOOKUP_COUNT: return "Index lookup count";
+        case FAST_PATH_COUNT: return "Fast path count";
+        case FAST_PATH_SHIFTS: return "Fast path shifts";
+        case SLOW_PATH_COUNT: return "Slow path count";
+        case SLOW_PATH_SHIFTS: return "Slow path shifts";
+        case VALIDATION_COUNT: return "Validation count";
+        case VALIDATION_BYTES_READ: return "Validation bytes read";
+        case VALIDATION_SHIFTS: return "Validation shifts";
+        case NUM_SHIFTS: return "Number of shifts";
+        case MATCH_COUNT: return "Number of matches";
+        case ALGO_VALUES: return "Per algorithm stats";
+    }
+    return "{Statname not defined}";
+}
+
+/*
+ * Returns the value of a stat in search info, given an enum for the stat.
+ * If you want the per algorithm stat values for the ALGO_VALUES enum, you must get that from the appropriate
+ * index in the searchStruct.algoValues[] array.  -1 will be returned if you ask for the ALGO_VALUES stat values.
+ */
+const long getStatValue(enum searchInfoStats stat, struct searchInfo* info) {
+    switch (stat) {
+        case PATTERN_LENGTH : return info->patternLength;
+        case TEXT_LENGTH: return info->textLength;
+        case SEARCH_INDEX_BYTES: return info->searchIndexBytes;
+        case SEARCH_INDEX_ENTRIES: return info->searchIndexEntries;
+        case MAIN_LOOP_COUNT: return info->mainLoopCount;
+        case TEXT_BYTES_READ: return info->textBytesRead;
+        case INDEX_LOOKUP_COUNT: return info->indexLookupCount;
+        case FAST_PATH_COUNT: return info->fastPathCount;
+        case FAST_PATH_SHIFTS: return info->fastPathShifts;
+        case SLOW_PATH_COUNT: return info->slowPathCount;
+        case SLOW_PATH_SHIFTS: return info->slowPathShifts;
+        case VALIDATION_COUNT: return info->validationCount;
+        case VALIDATION_BYTES_READ: return info->validationBytesRead;
+        case VALIDATION_SHIFTS: return info->validationShifts;
+        case NUM_SHIFTS: return info->numShifts;
+        case MATCH_COUNT: return info->matchCount;
+    }
+    return -1;
+}
+
+/*
+ * A struct holding an array of names for algorithm-specific stats.
+ */
+struct algoValueNames {
+    /*
+     * A short name for the statistic, which appears in the console output when benchmarking.
+     * The short name controls whether a statistic is processed.
+     * If it is empty, no stats will be reported, even if a long name is set.
+     */
+    char shortName[MAX_ALGO_VALUES][MAX_ALGO_VALUE_NAME_LEN];
+
+    /*
+     * A slightly longer name, which appears in the final report.
+     */
+    char longName[MAX_ALGO_VALUES][MAX_ALGO_VALUE_NAME_LEN];
+};
+
+
+/*
+ * A default struct indicating no results are available.  The pattern length is set to -1.
+ */
+struct searchInfo NO_ALGO_RESULTS = {-1};
+
+
+/*
+ * A default struct indicating no algorithm stat names.
+ */
+struct algoValueNames NO_ALGO_NAMES = {0};
+
+
+/*
+ * A convenience method to initialise the stats with a number of entries and the size of each entry.
+ */
+void initStats(struct searchInfo* info, int m, int n, int entries, int entrySize) {
+    info->patternLength = m;
+    info->textLength = n;
+    info->searchIndexEntries = entries;
+    info->searchIndexBytes = entries * entrySize;
+}
+
+
+/*
+ * A convenience method to initialize stats with the number of entries and the total number of bytes.
+ * This is for times when the memory size isn't computable by a single set of entries with a single size
+ * (e.g. some algorithms have two tables using different entry sizes for each).
+ */
+void initStatsBytes(struct searchInfo* info, int m, int n, int entries, int bytes) {
+    info->patternLength = m;
+    info->textLength = n;
+    info->searchIndexEntries = entries;
+    info->searchIndexBytes = bytes;
+}
+
+
+/*
+ * A convenience method to set an algorithm stat name.
+ */
+int setAlgoValueName(struct algoValueNames *names, int index, const char *shortName, const char *longName) {
+    if (index >= 0 && index < MAX_ALGO_VALUES) {
+        strncpy(names->shortName[index], shortName, MAX_ALGO_VALUE_NAME_LEN);
+        strncpy(names->longName[index], longName, MAX_ALGO_VALUE_NAME_LEN);
+        return 0;
+    }
+    printf("WARNING: cannot set algo name at index %d, valid range is 0 to %d", index, MAX_ALGO_VALUES - 1);
+    return 1;
+}
+
+
+/*
+ * A method to initialize a stat struct with default values.
+ */
+void clearSearchInfo(struct searchInfo *info) {
+    info->patternLength = -1;
+    info->textLength = 0;
+    info->searchIndexBytes=0;
+    info->searchIndexEntries=0;
+    info->mainLoopCount=0;
+    info->textBytesRead=0;
+    info->indexLookupCount=0;
+    info->fastPathCount=0;
+    info->fastPathShifts=0;
+    info->slowPathCount=0;
+    info->slowPathShifts=0;
+    info->validationCount=0;
+    info->validationBytesRead=0;
+    info->validationShifts=0;
+    info->numShifts=0;
+    info->matchCount=0;
+    for (int i = 0; i < MAX_ALGO_VALUES; i++) {
+        info->algoValues[i] = 0;
+    }
+}
+
+/*
+ * Calculates the average stat info given a set of totals and the number of samples.
+ * The average results are placed in the averageResuts struct passed in.
+ */
+void buildAverageSearchInfo(struct searchInfo *infoTotals, int samples, struct searchInfo *averageResults) {
+    averageResults->patternLength = infoTotals->patternLength > 0 ? infoTotals->patternLength / samples : -1;
+    averageResults->textLength = infoTotals->textLength / samples;
+    averageResults->searchIndexBytes = infoTotals->searchIndexBytes / samples;
+    averageResults->searchIndexEntries = infoTotals->searchIndexEntries / samples;
+    averageResults->mainLoopCount = infoTotals->mainLoopCount / samples;
+    averageResults->textBytesRead = infoTotals->textBytesRead / samples;
+    averageResults->indexLookupCount = infoTotals->indexLookupCount / samples;
+    averageResults->fastPathCount = infoTotals->fastPathCount / samples;
+    averageResults->fastPathShifts = infoTotals->fastPathShifts / samples;
+    averageResults->slowPathCount = infoTotals->slowPathCount / samples;
+    averageResults->slowPathShifts = infoTotals->slowPathShifts / samples;
+    averageResults->validationCount = infoTotals->validationCount / samples;
+    averageResults->validationBytesRead = infoTotals->validationBytesRead / samples;
+    averageResults->validationShifts = infoTotals->validationShifts / samples;
+    averageResults->numShifts = infoTotals->numShifts / samples;
+    averageResults->matchCount = infoTotals->matchCount / samples;
+    for (int i=0;i < MAX_ALGO_VALUES; i++) {
+        averageResults->algoValues[i] = infoTotals->algoValues[i] / samples;
+    }
+}
+
+
+/*
+ * Adds the values in one stat struct to another.
+ */
+void addSearchInfoTo(struct searchInfo *toAdd, struct searchInfo *addTo) {
+    addTo->patternLength += toAdd->patternLength;
+    addTo->textLength += toAdd->textLength;
+    addTo->searchIndexBytes += toAdd->searchIndexBytes;
+    addTo->searchIndexEntries += toAdd->searchIndexEntries;
+    addTo->mainLoopCount += toAdd->mainLoopCount;
+    addTo->textBytesRead += toAdd->textBytesRead;
+    addTo->indexLookupCount += toAdd->indexLookupCount;
+    addTo->fastPathCount += toAdd->fastPathCount;
+    addTo->fastPathShifts += toAdd->fastPathShifts;
+    addTo->slowPathCount += toAdd->slowPathCount;
+    addTo->slowPathShifts += toAdd->slowPathShifts;
+    addTo->validationCount += toAdd->validationCount;
+    addTo->validationBytesRead += toAdd->validationBytesRead;
+    addTo->validationShifts += toAdd->validationShifts;
+    addTo->numShifts += toAdd->numShifts;
+    addTo->matchCount += toAdd->matchCount;
+    for (int i = 0; i < MAX_ALGO_VALUES; i++) {
+        addTo->algoValues[i] += toAdd->algoValues[i];
+    }
+}
+
+
+/*
+ * Prints the algo value names to the console.
+ */
+void printAlgoValueNames(const char *format, const struct algoValueNames *valueNames) {
+    for (int i = 0; i < MAX_ALGO_VALUES; i++) {
+        const char * valueName = valueNames->shortName[i];
+        if (valueName[0] != '\0') {
+            printf(format, valueName);
+        }
+    }
+}
+
+
+/*
+ * Prints all search info to the console.
+ */
+void printSearchInfo(const char *format, const struct searchInfo *searchInfo, const struct algoValueNames *valueNames) {
+    printf(format, "Pattern length", searchInfo->patternLength);
+    printf(format, "Text length", searchInfo->textLength);
+    printf(format, "Index bytes", searchInfo->searchIndexBytes);
+    printf(format, "Index entries", searchInfo->searchIndexEntries);
+    printf(format, "Main loop count", searchInfo->mainLoopCount);
+    printf(format, "Text bytes read", searchInfo->textBytesRead);
+    printf(format, "Index lookup count", searchInfo->indexLookupCount);
+    printf(format, "Fast path count", searchInfo->fastPathCount);
+    printf(format, "Fast path shifts", searchInfo->fastPathShifts);
+    printf(format, "Slow path count", searchInfo->slowPathCount);
+    printf(format, "Slow path shifts", searchInfo->slowPathShifts);
+    printf(format, "Validation count", searchInfo->validationCount);
+    printf(format, "Validation bytes read", searchInfo->validationBytesRead);
+    printf(format, "Validation shifts", searchInfo->validationShifts);
+    printf(format, "Num shifts", searchInfo->numShifts);
+    printf(format, "Match count", searchInfo->matchCount);
+    for (int i = 0; i < MAX_ALGO_VALUES; i++) {
+        const char * shortName = valueNames->shortName[i];
+        if (shortName[0] != '\0') {
+            const char * longName = valueNames->longName[i];
+            const char * nameToUse = longName[0] != '\0'? longName : shortName;
+            printf(format, nameToUse, searchInfo->algoValues[i]);
+        }
+    }
+}
+
+#endif //SMART_SEARCHINFO_H

--- a/source/smart.c
+++ b/source/smart.c
@@ -489,6 +489,9 @@ int run_setting(char *filename, key_t tkey, unsigned char* T, int n,
                 struct searchInfo averageSearchInfo = TOTAL_INFO[algo][il];
                 printf("\tmem=%ld", averageSearchInfo.searchIndexBytes);
                 printf(", entries=%ld", averageSearchInfo.searchIndexEntries);
+                if (averageSearchInfo.searchIndex2Entries > 0) {
+                    printf(", entries2=%ld", averageSearchInfo.searchIndex2Entries);
+                }
                 printf(", bytesRead=%ld", averageSearchInfo.textBytesRead);
                 printf(", numShifts=%ld", averageSearchInfo.numShifts);
                 printf(", validations=%ld", averageSearchInfo.validationCount);

--- a/source/smart.c
+++ b/source/smart.c
@@ -488,13 +488,13 @@ int run_setting(char *filename, key_t tkey, unsigned char* T, int n,
             if(gotStats) {
                 struct searchInfo averageSearchInfo = TOTAL_INFO[algo][il];
                 printf("\tmem=%ld", averageSearchInfo.searchIndexBytes);
-                printf(", entries=%ld", averageSearchInfo.searchIndexEntries);
+                printf(", size=%ld", averageSearchInfo.searchIndexEntries);
                 if (averageSearchInfo.searchIndex2Entries > 0) {
-                    printf(", entries2=%ld", averageSearchInfo.searchIndex2Entries);
+                    printf(", size2=%ld", averageSearchInfo.searchIndex2Entries);
                 }
-                printf(", bytesRead=%ld", averageSearchInfo.textBytesRead);
-                printf(", numShifts=%ld", averageSearchInfo.numShifts);
-                printf(", validations=%ld", averageSearchInfo.validationCount);
+                printf(", bytes=%ld", averageSearchInfo.textBytesRead);
+                printf(", shifts=%ld", averageSearchInfo.numShifts);
+                printf(", tests=%ld", averageSearchInfo.validationCount);
                 for (int i=0; i<MAX_ALGO_VALUES;i++) {
                     const char * valueName = statNames->shortName[i];
                     if(valueName[0] != '\0') {

--- a/source/smart.c
+++ b/source/smart.c
@@ -406,7 +406,7 @@ int run_setting(char *filename, key_t tkey, unsigned char* T, int n,
             if (obtainStats) {
                 clearSearchInfo(searchInfo);
                 int statReturn = getStats(algo,pkey,m,tkey,n,sikey); // stats placed in shared memory *sharedInfo
-                if (statReturn == 0 && searchInfo->patternLength > 0) { // algorithm supports stats and has set results.
+                if (statReturn == 0 && searchInfo->hasStats) { // algorithm supports stats and has set results.
                     addSearchInfoTo(searchInfo, &(TOTAL_INFO[algo][il]));
                     gotStats = 1;
                 }
@@ -439,6 +439,7 @@ int run_setting(char *filename, key_t tkey, unsigned char* T, int n,
 				PRE_TIME[algo][il]=0;
                 clearSearchInfo(&(TOTAL_INFO[algo][il]));
                 total_occur = -2;
+                gotStats = 0;
 				break;
 	      	}
       	}
@@ -518,10 +519,16 @@ int run_setting(char *filename, key_t tkey, unsigned char* T, int n,
 	   if(tex) outputLatex(TIME, alpha, filename, code, time_format);
 	   if(php) outputPHP(TIME, BEST, WORST, STD, alpha, filename, code, dif, std);
    }
-   //free shared memory //TODO: what about other ones?
+   //free shared memory
    shmctl(pshmid, IPC_RMID,0);
    shmctl(rshmid, IPC_RMID,0);
-   
+   shmctl(eshmid, IPC_RMID, 0);
+   shmctl(preshmid, IPC_RMID, 0);
+   if (stats) {
+       shmctl(sishmid, IPC_RMID, 0);
+       shmctl(snshmid, IPC_RMID, 0);
+   }
+
    //free memory allocated for patterns
    for(i=0; i<VOLTE; i++) free(setP[i]);
    free(setP);


### PR DESCRIPTION
This PR has changes which allow algorithms to report running statistics.

* Algorithms that don't implement statistics don't have to do anything.
* A wide range of stats can be reported on, including memory, size of tables, number of shifts, fast path count, etc.
* An algorithm can define up to 8 algorithm-specific stats it wishes to report on.
* Stats summaries are given when running in the console, written out to the HTML reports, and to a tab-delimited text file.

**Running**
To obtain stats in a run, use the `-stats` flag:
```
   ./smart -text englishTexts -pre -stats
____________________________________________________________
Experimental results on englishTexts: EXP1653747757
Searching for a set of 500 patterns with length 4
Testing 2 algorithms

 - [1/2] TWFR4 ...............[OK]  	0.01 + 1.82 ms     
 - [2/2] WFR4 ................[OK]  	0.02 + 2.40 ms     	mem=65536, size=65536, bytes=4202857, shifts=1048572, tests=2470, bits=9, empty=65526
____________________________________________________________
Experimental results on englishTexts: EXP1653747757
Searching for a set of 500 patterns with length 8
Testing 2 algorithms

 - [1/2] TWFR4 ...............[OK]  	0.01 + 0.73 ms     
 - [2/2] WFR4 ................[OK]  	0.02 + 0.84 ms     	mem=65536, size=65536, bytes=865484, shifts=212562, tests=126, bits=33, empty=65502
____________________________________________________________
```

**Standard Stats**
It's entirely up to the implementer what stats are reported, but a standard set of statistics is provided that fit most search algorithms.
```C
enum searchInfoStats {
    TEXT_LENGTH,             // length of text searched
    SEARCH_INDEX_BYTES,      // memory consumed by search indexes
    SEARCH_INDEX_ENTRIES,    // number of entries in the search index
    SEARCH_INDEX2_ENTRIES,   // number of entries in the second search index (if present)
    MAIN_LOOP_COUNT,         // number of times the main loop executes
    TEXT_BYTES_READ,         // number of bytes read from the text
    INDEX_LOOKUP_COUNT,      // number of times a lookup in an index is made
    FAST_PATH_COUNT,         // number of times the fast path is taken.
    FAST_PATH_SHIFTS,        // sum of shifts obtained in the fast path
    SLOW_PATH_COUNT,         // number of times the slow path is taken.
    SLOW_PATH_SHIFTS,        // sum of shifts obtained in the slow path
    VALIDATION_COUNT,        // number of times a pattern validation is attempted
    VALIDATION_BYTES_READ,   // text bytes read during pattern validation
    VALIDATION_SHIFTS,       // sum of shifts obtained following validation
    NUM_SHIFTS,              // number of times the algorithm actually shifts (not the sum of the shifts)
    MATCH_COUNT,             // the number of matches the algorithm detects
    ALGO_VALUES              // algorithm defined values (up to 8)
};
```
**Algorithm defined Stats**
Algorithms can define up to 8 stats particular to an algorithm.  To do this, they must implement the `getAlgoValueNames()` function.  These are often the same for particular kinds of algorithm.  Below is an example from `\include\bitstats.h`, which defines two stats useful for some bit-oriented algorithms.
```C
struct algoValueNames getAlgoValueNames() {
    struct algoValueNames names = {0};
    setAlgoValueName(&names, 0, "bits", "Count of bits set in index");
    setAlgoValueName(&names, 1, "empty", "Count of empty index entries");
    return names;
}
```
If you don't want to implement any special stats for an algorithm, an empty set of stat names should be returned:
```C
struct algoValueNames getAlgoValueNames() {
    struct algoValueNames names = {0};
    return names;
}
```
**Algorithms**
This PR makes no changes to any existing algorithms, so on it's own, running `-stats` will do nothing - no algorithms support it!
I'll submit changes to families of existing algorithms which have had stats added to them in batches in further PRs.
To test stats, you should look at these PRs, which are branched off this.  
