### PR TITLE
Implementation of WFR with Q-gram pre-processing (no stats)

### DIFF
--- a/source/algos/wfrq2.c
+++ b/source/algos/wfrq2.c
@@ -1,0 +1,106 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ *
+ *  THIS IS AN IMPLEMENTATION OF:
+ *	ALGORITHM Weak Factor Recognizer (WFR) Using Q-Grams
+ *  appeared in: Simone Faro, Domenico Cantone and Arianna Pavone.
+ *  Speeding Up String Matching by Weak Factor Recognition.
+ *  Proceedings of the Pague Stringology Conference 2017: pp.42-50
+ *
+ *  This variant of WFR, by Matt Palmer (matt.palmer@bcs.org), improves search speed and pre-processing time
+ *  by pre-processing hashes of the q-grams of the pattern rather than the bytes of the pattern.
+ *  As a result, fewer bits are set in the hash table during pre-processing and fewer false positives arise in the search phase.
+ *
+ * PREPROCESSING:
+ *		an hash value is computed for all q-gram factors of the pattern with length in [1..8]
+ *		the computed hash value is always a number in [0...256*256]
+ *		if w is a factor of x, and hash(w) is its hash value, than F[hash(w)]=TRUE, otherwise F[hash(w)]=FALSE
+ * SEARCHING
+ *		The algorithm searches for factors of the pattern using a weak recognition method
+ *		the search phase is very similar to BOM.
+ *		The window is scanned right to left and for each character a new hash value of the suffix of the window is computed.
+ *		Let w be the suffix we scanned. If F[hash(w)]=TRUE we continue scanning the next character of the window.
+ *		Otherwise we stop scanning (w is not a factor of the pattern) and jump to the right, like in BOM.
+ */
+
+
+#include "include/define.h"
+#include "include/main.h"
+#include "include/GRAPH.h"
+#define Q 2
+#define HASH(j) (y[j]<<2) + y[j-1]
+
+/*
+ * Pre-process q-gram factors of the pattern.
+ */
+int preprocessingQ(unsigned char *x, int m, char *F) {
+    int i,j;
+    unsigned short h;
+    int fact = m < 8 ? m : 8;
+    for(i=0; i<256*256; i++) F[i] = FALSE;
+    for(i=Q-1; i<m; i++) {
+        int stop = (i-fact+1)>=Q-1?(i-fact+1):Q-1;
+        h = (x[i]<<2) + x[i-1];
+        F[h] = TRUE;
+        for(j=i-Q; j>=stop; j-=Q) {
+            h = (h<<4) + (x[j]<<2) + x[j-1];
+            F[h] = TRUE;
+        }
+    }
+}
+
+
+int search(unsigned char *x, int m, unsigned char *y, int n) {
+    int i, j, p, k, count, test;
+    char F[256*256];
+    unsigned short h;
+    if(m<Q) return -1;
+
+    BEGIN_PREPROCESSING
+    /* Preprocessing */
+    int plen = m;
+    if(m%Q==1) m = m-1;
+    int mq = m-Q+1;
+    preprocessingQ(x,m,F);
+    for(i=0; i<m; i++) y[n+i]=x[i];
+    END_PREPROCESSING
+
+    BEGIN_SEARCHING
+    /* Searching */
+    count = 0;
+    if( !memcmp(x,y,plen) ) count++;
+    j=m;
+    while (j < n) {
+        h = HASH(j);
+        i = j-m+Q;
+        while((test=F[h]) && j>i+Q-1) {
+            j-=Q;
+            h = (h<<4) + HASH(j);
+        }
+        if(j==i && test) {
+            k=0;
+            i -= Q-1;
+            while(k<plen && x[k]==y[i+k]) k++;
+            if(k==plen && i<=n-plen)
+                count++;
+        }
+        j+=m-Q+1;
+    }
+    END_SEARCHING
+    return count;
+}

--- a/source/algos/wfrq3.c
+++ b/source/algos/wfrq3.c
@@ -1,0 +1,108 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ *
+ *  THIS IS AN IMPLEMENTATION OF:
+ *	ALGORITHM Weak Factor Recognizer (WFR) Using Q-Grams
+ *  appeared in: Simone Faro, Domenico Cantone and Arianna Pavone.
+ *  Speeding Up String Matching by Weak Factor Recognition.
+ *  Proceedings of the Pague Stringology Conference 2017: pp.42-50
+ *
+ *  This variant of WFR, by Matt Palmer (matt.palmer@bcs.org), improves search speed and pre-processing time
+ *  by pre-processing hashes of the q-grams of the pattern rather than the bytes of the pattern.
+ *  As a result, fewer bits are set in the hash table during pre-processing and fewer false positives arise in the search phase.
+ *
+ * PREPROCESSING:
+ *		an hash value is computed for all q-gram factors of the pattern with length in [1..8]
+ *		the computed hash value is always a number in [0...256*256]
+ *		if w is a factor of x, and hash(w) is its hash value, than F[hash(w)]=TRUE, otherwise F[hash(w)]=FALSE
+ * SEARCHING
+ *		The algorithm searches for factors of the pattern using a weak recognition method
+ *		the search phase is very similar to BOM.
+ *		The window is scanned right to left and for each character a new hash value of the suffix of the window is computed.
+ *		Let w be the suffix we scanned. If F[hash(w)]=TRUE we continue scanning the next character of the window.
+ *		Otherwise we stop scanning (w is not a factor of the pattern) and jump to the right, like in BOM.
+ */
+
+#include "include/define.h"
+#include "include/main.h"
+#include "include/GRAPH.h"
+#define Q 3
+#define HASH(j) (y[j]<<4) + (y[j-1]<<2) + y[j-2]
+
+/*
+ * Pre-process q-gram factors of the pattern.
+ */
+int preprocessingQ(unsigned char *x, int m, char *F) {
+    int i,j;
+    unsigned short h;
+    int fact = m < 8 ? m : 8;
+    for(i=0; i<256*256; i++) F[i] = FALSE;
+    for(i=Q-1; i<m; i++) {
+        int stop = (i-fact+1)>=Q-1?(i-fact+1):Q-1;
+        h = (x[i]<<4) + (x[i-1]<<2) + x[i-2];
+        F[h] = TRUE;
+        for(j=i-Q; j>=stop; j-=Q) {
+            h = (h<<6) + (x[j]<<4) + (x[j-1]<<2) + x[j-2];
+            F[h] = TRUE;
+        }
+    }
+}
+
+
+int search(unsigned char *x, int m, unsigned char *y, int n) {
+    int i, j, p, k, count, test;
+    char F[256*256];
+    unsigned short h;
+    if(m<Q) return -1;
+
+    BEGIN_PREPROCESSING
+    /* Preprocessing */
+    int plen = m;
+    if(m%Q!=0) m = m-(m%Q);
+    int mq = m-Q+1;
+    preprocessingQ(x,m,F);
+    for(i=0; i<m; i++) y[n+i]=x[i];
+    END_PREPROCESSING
+
+    BEGIN_SEARCHING
+    /* Searching */
+    count = 0;
+    if( !memcmp(x,y,plen) ) count++;
+    j=m;
+    while (j < n) {
+        h = HASH(j);
+        i = j-m+Q;
+        while((test=F[h]) && j>i+Q-1) {
+            j-=Q;
+            h = (h<<6) + HASH(j);
+        }
+        if(j==i && test) {
+            k=0;
+            i -= Q-1;
+            while(k<plen && x[k]==y[i+k]) k++;
+            if(k==plen && i<=n-plen)
+                count++;
+        }
+        j+=m-Q+1;
+    }
+    END_SEARCHING
+    return count;
+}
+
+
+

--- a/source/algos/wfrq4.c
+++ b/source/algos/wfrq4.c
@@ -1,0 +1,105 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ *
+ *  THIS IS AN IMPLEMENTATION OF:
+ *	ALGORITHM Weak Factor Recognizer (WFR) Using Q-Grams
+ *  appeared in: Simone Faro, Domenico Cantone and Arianna Pavone.
+ *  Speeding Up String Matching by Weak Factor Recognition.
+ *  Proceedings of the Pague Stringology Conference 2017: pp.42-50
+ *
+ *  This variant of WFR, by Matt Palmer (matt.palmer@bcs.org), improves search speed and pre-processing time
+ *  by pre-processing hashes of the q-grams of the pattern rather than the bytes of the pattern.
+ *  As a result, fewer bits are set in the hash table during pre-processing and fewer false positives arise in the search phase.
+ *
+ * PREPROCESSING:
+ *		an hash value is computed for all q-gram factors of the pattern with length in [1..8]
+ *		the computed hash value is always a number in [0...256*256]
+ *		if w is a factor of x, and hash(w) is its hash value, than F[hash(w)]=TRUE, otherwise F[hash(w)]=FALSE
+ * SEARCHING
+ *		The algorithm searches for factors of the pattern using a weak recognition method
+ *		the search phase is very similar to BOM.
+ *		The window is scanned right to left and for each character a new hash value of the suffix of the window is computed.
+ *		Let w be the suffix we scanned. If F[hash(w)]=TRUE we continue scanning the next character of the window.
+ *		Otherwise we stop scanning (w is not a factor of the pattern) and jump to the right, like in BOM.
+ */
+
+#include "include/define.h"
+#include "include/main.h"
+#include "include/GRAPH.h"
+#define Q 4
+#define HASH(j) (y[j]<<6) + (y[j-1]<<4) + (y[j-2]<<2) + y[j-3]
+
+/*
+ * Pre-process q-gram factors of the pattern.
+ */
+int preprocessingQ(unsigned char *x, int m, char *F) {
+    int i,j;
+    unsigned short h;
+    int fact = m < 8 ? m : 8;
+    for(i=0; i<256*256; i++) F[i] = FALSE;
+    for(i=Q-1; i<m; i++) {
+        int stop = (i-fact+1)>=Q-1?(i-fact+1):Q-1;
+        h = (x[i]<<6) + (x[i-1]<<4) + (x[i-2]<<2) + x[i-3];
+        F[h] = TRUE;
+        for(j=i-Q; j>=stop; j-=Q) {
+            h = (h<<8) + (x[j]<<6) + (x[j-1]<<4) + (x[j-2]<<2) + x[j-3];
+            F[h] = TRUE;
+        }
+    }
+}
+
+
+int search(unsigned char *x, int m, unsigned char *y, int n) {
+    int i, j, p, k, count, test;
+    char F[256*256];
+    unsigned short h;
+    if(m<Q) return -1;
+
+    BEGIN_PREPROCESSING
+    /* Preprocessing */
+    int plen = m;
+    if(m%Q!=0) m = m-(m%Q);
+    int mq = m-Q+1;
+    preprocessingQ(x,m,F);
+    for(i=0; i<m; i++) y[n+i]=x[i];
+    END_PREPROCESSING
+
+    BEGIN_SEARCHING
+    /* Searching */
+    count = 0;
+    if( !memcmp(x,y,plen) ) count++;
+    j=m;
+    while (j < n) {
+        h = HASH(j);
+        i = j-m+1;
+        while((test=F[h]) && j>i+Q-1) {
+            j-=Q;
+            h = (h<<8) + HASH(j);
+        }
+        if(j==i+Q-1 && test) {
+            k=0;
+            while(k<plen && x[k]==y[i+k]) k++;
+            if(k==plen && i<=n-plen)
+                count++;
+        }
+        j+=m-Q+1;
+    }
+    END_SEARCHING
+    return count;
+}
+

--- a/source/algos/wfrq5.c
+++ b/source/algos/wfrq5.c
@@ -1,0 +1,104 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ *
+ *  THIS IS AN IMPLEMENTATION OF:
+ *	ALGORITHM Weak Factor Recognizer (WFR) Using Q-Grams
+ *  appeared in: Simone Faro, Domenico Cantone and Arianna Pavone.
+ *  Speeding Up String Matching by Weak Factor Recognition.
+ *  Proceedings of the Pague Stringology Conference 2017: pp.42-50
+ *
+ *  This variant of WFR, by Matt Palmer (matt.palmer@bcs.org), improves search speed and pre-processing time
+ *  by pre-processing hashes of the q-grams of the pattern rather than the bytes of the pattern.
+ *  As a result, fewer bits are set in the hash table during pre-processing and fewer false positives arise in the search phase.
+ *
+ * PREPROCESSING:
+ *		an hash value is computed for all q-gram factors of the pattern with length in [1..8]
+ *		the computed hash value is always a number in [0...256*256]
+ *		if w is a factor of x, and hash(w) is its hash value, than F[hash(w)]=TRUE, otherwise F[hash(w)]=FALSE
+ * SEARCHING
+ *		The algorithm searches for factors of the pattern using a weak recognition method
+ *		the search phase is very similar to BOM.
+ *		The window is scanned right to left and for each character a new hash value of the suffix of the window is computed.
+ *		Let w be the suffix we scanned. If F[hash(w)]=TRUE we continue scanning the next character of the window.
+ *		Otherwise we stop scanning (w is not a factor of the pattern) and jump to the right, like in BOM.
+ */
+#include "include/define.h"
+#include "include/main.h"
+#include "include/GRAPH.h"
+#define Q 5
+#define HASH(j) (y[j]<<8) + (y[j-1]<<6) + (y[j-2]<<4) + (y[j-3]<<2) + y[j-4]
+
+/*
+ * Pre-process q-gram factors of the pattern.
+ */
+int preprocessingQ(unsigned char *x, int m, char *F) {
+    int i,j;
+    unsigned short h;
+    int fact = m < 8 ? m : 8;
+    for(i=0; i<256*256; i++) F[i] = FALSE;
+    for(i=Q-1; i<m; i++) {
+        int stop = (i-fact+1)>=Q-1?(i-fact+1):Q-1;
+        h = (x[i]<<8) + (x[i-1]<<6) + (x[i-2]<<4) + (x[i-3]<<2) + x[i-4];
+        F[h] = TRUE;
+        for(j=i-Q; j>=stop; j-=Q) {
+            h = (h<<10) + (x[j]<<8) + (x[j-1]<<6) + (x[j-2]<<4) + (x[j-3]<<2) + x[j-4];
+            F[h] = TRUE;
+        }
+    }
+}
+
+
+int search(unsigned char *x, int m, unsigned char *y, int n) {
+    int i, j, p, k, count, test;
+    char F[256*256];
+    unsigned short h;
+    if(m<Q) return -1;
+
+    BEGIN_PREPROCESSING
+    /* Preprocessing */
+    int plen = m;
+    if(m%Q!=0) m = m-(m%Q);
+    int mq = m-Q+1;
+    preprocessingQ(x,m,F);
+    for(i=0; i<m; i++) y[n+i]=x[i];
+    END_PREPROCESSING
+
+    BEGIN_SEARCHING
+    /* Searching */
+    count = 0;
+    if( !memcmp(x,y,plen) ) count++;
+    j=m;
+    while (j < n) {
+        h = HASH(j);
+        i = j-m+1;
+        while((test=F[h]) && j>i+Q-1) {
+            j-=Q;
+            h = (h<<10) + HASH(j);
+        }
+        if(j==i+Q-1 && test) {
+            k=0;
+            while(k<plen && x[k]==y[i+k]) k++;
+            if(k==plen && i<=n-plen)
+                count++;
+        }
+        j+=m-Q+1;
+    }
+    END_SEARCHING
+    return count;
+}
+

--- a/source/algos/wfrq6.c
+++ b/source/algos/wfrq6.c
@@ -1,0 +1,105 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ *
+ *  THIS IS AN IMPLEMENTATION OF:
+ *	ALGORITHM Weak Factor Recognizer (WFR) Using Q-Grams
+ *  appeared in: Simone Faro, Domenico Cantone and Arianna Pavone.
+ *  Speeding Up String Matching by Weak Factor Recognition.
+ *  Proceedings of the Pague Stringology Conference 2017: pp.42-50
+ *
+ *  This variant of WFR, by Matt Palmer (matt.palmer@bcs.org), improves search speed and pre-processing time
+ *  by pre-processing hashes of the q-grams of the pattern rather than the bytes of the pattern.
+ *  As a result, fewer bits are set in the hash table during pre-processing and fewer false positives arise in the search phase.
+ *
+ * PREPROCESSING:
+ *		an hash value is computed for all q-gram factors of the pattern with length in [1..8]
+ *		the computed hash value is always a number in [0...256*256]
+ *		if w is a factor of x, and hash(w) is its hash value, than F[hash(w)]=TRUE, otherwise F[hash(w)]=FALSE
+ * SEARCHING
+ *		The algorithm searches for factors of the pattern using a weak recognition method
+ *		the search phase is very similar to BOM.
+ *		The window is scanned right to left and for each character a new hash value of the suffix of the window is computed.
+ *		Let w be the suffix we scanned. If F[hash(w)]=TRUE we continue scanning the next character of the window.
+ *		Otherwise we stop scanning (w is not a factor of the pattern) and jump to the right, like in BOM.
+ */
+
+#include "include/define.h"
+#include "include/main.h"
+#include "include/GRAPH.h"
+#define Q 6
+#define HASH(j) (y[j]<<10) + (y[j-1]<<8) + (y[j-2]<<6) + (y[j-3]<<4) + (y[j-4]<<2) + y[j-5]
+
+/*
+ * Pre-process q-gram factors of the pattern.
+ */
+int preprocessingQ(unsigned char *x, int m, char *F) {
+    int i,j;
+    unsigned short h;
+    int fact = m < 8 ? m : 8;
+    for(i=0; i<256*256; i++) F[i] = FALSE;
+    for(i=Q-1; i<m; i++) {
+        int stop = (i-fact+1)>=Q-1?(i-fact+1):Q-1;
+        h = (x[i]<<10) + (x[i-1]<<8) + (x[i-2]<<6) + (x[i-3]<<4) + (x[i-4]<<2) + x[i-5];
+        F[h] = TRUE;
+        for(j=i-Q; j>=stop; j-=Q) {
+            h = (h<<12) + (x[j]<<10) + (x[j-1]<<8) + (x[j-2]<<6) + (x[j-3]<<4) + (x[j-4]<<2) + x[j-5];
+            F[h] = TRUE;
+        }
+    }
+}
+
+
+int search(unsigned char *x, int m, unsigned char *y, int n) {
+    int i, j, p, k, count, test;
+    char F[256*256];
+    unsigned short h;
+    if(m<Q) return -1;
+
+    BEGIN_PREPROCESSING
+    /* Preprocessing */
+    int plen = m;
+    if(m%Q!=0) m = m-(m%Q);
+    int mq = m-Q+1;
+    preprocessingQ(x,m,F);
+    for(i=0; i<m; i++) y[n+i]=x[i];
+    END_PREPROCESSING
+
+    BEGIN_SEARCHING
+    /* Searching */
+    count = 0;
+    if( !memcmp(x,y,plen) ) count++;
+    j=m;
+    while (j < n) {
+        h = HASH(j);
+        i = j-m+1;
+        while((test=F[h]) && j>i+Q-1) {
+            j-=Q;
+            h = (h<<12) + HASH(j);
+        }
+        if(j==i+Q-1 && test) {
+            k=0;
+            while(k<plen && x[k]==y[i+k]) k++;
+            if(k==plen && i<=n-plen)
+                count++;
+        }
+        j+=m-Q+1;
+    }
+    END_SEARCHING
+    return count;
+}
+

--- a/source/algos/wfrq7.c
+++ b/source/algos/wfrq7.c
@@ -1,0 +1,106 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ *
+ *  THIS IS AN IMPLEMENTATION OF:
+ *	ALGORITHM Weak Factor Recognizer (WFR) Using Q-Grams
+ *  appeared in: Simone Faro, Domenico Cantone and Arianna Pavone.
+ *  Speeding Up String Matching by Weak Factor Recognition.
+ *  Proceedings of the Pague Stringology Conference 2017: pp.42-50
+ *
+ *  This variant of WFR, by Matt Palmer (matt.palmer@bcs.org), improves search speed and pre-processing time
+ *  by pre-processing hashes of the q-grams of the pattern rather than the bytes of the pattern.
+ *  As a result, fewer bits are set in the hash table during pre-processing and fewer false positives arise in the search phase.
+ *
+ * PREPROCESSING:
+ *		an hash value is computed for all q-gram factors of the pattern with length in [1..8]
+ *		the computed hash value is always a number in [0...256*256]
+ *		if w is a factor of x, and hash(w) is its hash value, than F[hash(w)]=TRUE, otherwise F[hash(w)]=FALSE
+ * SEARCHING
+ *		The algorithm searches for factors of the pattern using a weak recognition method
+ *		the search phase is very similar to BOM.
+ *		The window is scanned right to left and for each character a new hash value of the suffix of the window is computed.
+ *		Let w be the suffix we scanned. If F[hash(w)]=TRUE we continue scanning the next character of the window.
+ *		Otherwise we stop scanning (w is not a factor of the pattern) and jump to the right, like in BOM.
+ */
+
+
+#include "include/define.h"
+#include "include/main.h"
+#include "include/GRAPH.h"
+#define Q 7
+#define HASH(j) (y[j]<<12) + (y[j-1]<<10) + (y[j-2]<<8) + (y[j-3]<<6) + (y[j-4]<<4) + (y[j-5]<<2) + y[j-6]
+
+/*
+ * Pre-process q-gram factors of the pattern.
+ */
+int preprocessingQ(unsigned char *x, int m, char *F) {
+    int i,j;
+    unsigned short h;
+    int fact = m < 8 ? m : 8;
+    for(i=0; i<256*256; i++) F[i] = FALSE;
+    for(i=Q-1; i<m; i++) {
+        int stop = (i-fact+1)>=Q-1?(i-fact+1):Q-1;
+        h = (x[i]<<12) + (x[i-1]<<10) + (x[i-2]<<8) + (x[i-3]<<6) + (x[i-4]<<4) + (x[i-5]<<2) + x[i-6];
+        F[h] = TRUE;
+        for(j=i-Q; j>=stop; j-=Q) {
+            h = (h<<14) + (x[j]<<12) + (x[j-1]<<10) + (x[j-2]<<8) + (x[j-3]<<6) + (x[j-4]<<4) + (x[j-5]<<2) + x[j-6];
+            F[h] = TRUE;
+        }
+    }
+}
+
+
+int search(unsigned char *x, int m, unsigned char *y, int n) {
+    int i, j, p, k, count, test;
+    char F[256*256];
+    unsigned short h;
+    if(m<Q) return -1;
+
+    BEGIN_PREPROCESSING
+    /* Preprocessing */
+    int plen = m;
+    if(m%Q!=0) m = m-(m%Q);
+    int mq = m-Q+1;
+    preprocessingQ(x,m,F);
+    for(i=0; i<m; i++) y[n+i]=x[i];
+    END_PREPROCESSING
+
+    BEGIN_SEARCHING
+    /* Searching */
+    count = 0;
+    if( !memcmp(x,y,plen) ) count++;
+    j=m;
+    while (j < n) {
+        h = HASH(j);
+        i = j-m+1;
+        while((test=F[h]) && j>i+Q-1) {
+            j-=Q;
+            h = (h<<14) + HASH(j);
+        }
+        if(j==i+Q-1 && test) {
+            k=0;
+            while(k<plen && x[k]==y[i+k]) k++;
+            if(k==plen && i<=n-plen)
+                count++;
+        }
+        j+=m-Q+1;
+    }
+    END_SEARCHING
+    return count;
+}
+

--- a/source/algos/wfrq8.c
+++ b/source/algos/wfrq8.c
@@ -1,0 +1,104 @@
+/*
+ * SMART: string matching algorithms research tool.
+ * Copyright (C) 2012  Simone Faro and Thierry Lecroq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * contact the authors at: faro@dmi.unict.it, thierry.lecroq@univ-rouen.fr
+ * download the tool at: http://www.dmi.unict.it/~faro/smart/
+ *
+ *  THIS IS AN IMPLEMENTATION OF:
+ *	ALGORITHM Weak Factor Recognizer (WFR) Using Q-Grams
+ *  appeared in: Simone Faro, Domenico Cantone and Arianna Pavone.
+ *  Speeding Up String Matching by Weak Factor Recognition.
+ *  Proceedings of the Pague Stringology Conference 2017: pp.42-50
+ *
+ *  This variant of WFR, by Matt Palmer (matt.palmer@bcs.org), improves search speed and pre-processing time
+ *  by pre-processing hashes of the q-grams of the pattern rather than the bytes of the pattern.
+ *  As a result, fewer bits are set in the hash table during pre-processing and fewer false positives arise in the search phase.
+ *
+ * PREPROCESSING:
+ *		an hash value is computed for all q-gram factors of the pattern with length in [1..8]
+ *		the computed hash value is always a number in [0...256*256]
+ *		if w is a factor of x, and hash(w) is its hash value, than F[hash(w)]=TRUE, otherwise F[hash(w)]=FALSE
+ * SEARCHING
+ *		The algorithm searches for factors of the pattern using a weak recognition method
+ *		the search phase is very similar to BOM.
+ *		The window is scanned right to left and for each character a new hash value of the suffix of the window is computed.
+ *		Let w be the suffix we scanned. If F[hash(w)]=TRUE we continue scanning the next character of the window.
+ *		Otherwise we stop scanning (w is not a factor of the pattern) and jump to the right, like in BOM.
+ */
+
+#include "include/define.h"
+#include "include/main.h" // defines the search interface for time and statistics.
+#include "include/GRAPH.h"
+#define Q 8
+#define HASH(j) (y[j]<<14) + (y[j-1]<<12) + (y[j-2]<<10) + (y[j-3]<<8) + (y[j-4]<<6) + (y[j-5]<<4) + (y[j-6]<<2) + y[j-7]
+
+/*
+ * Pre-process q-gram factors of the pattern.
+ */
+int preprocessingQ(unsigned char *x, int m, char *F) {
+    int i,j;
+    unsigned short h;
+    int fact = m < 8 ? m : 8;
+    for(i=0; i<256*256; i++) F[i] = FALSE;
+    for(i=Q-1; i<m; i++) {
+        int stop = (i-fact+1)>=Q-1?(i-fact+1):Q-1;
+        h = (x[i]<<14) + (x[i-1]<<12) + (x[i-2]<<10) + (x[i-3]<<8) + (x[i-4]<<6) + (x[i-5]<<4) + (x[i-6]<<2) + x[i-7];
+        F[h] = TRUE;
+        for(j=i-Q; j>=stop; j-=Q) {
+            h = (h<<16) + (x[j]<<14) + (x[j-1]<<12) + (x[j-2]<<10) + (x[j-3]<<8) + (x[j-4]<<6) + (x[j-5]<<4) + (x[j-6]<<2) + x[j-7];
+            F[h] = TRUE;
+        }
+    }
+}
+
+
+int search(unsigned char *x, int m, unsigned char *y, int n) {
+    int i, j, p, k, count, test;
+    char F[256*256];
+    unsigned short h;
+    if(m<Q) return -1;
+
+    BEGIN_PREPROCESSING
+    /* Preprocessing */
+    int plen = m;
+    if(m%Q!=0) m = m-(m%Q);
+    int mq = m-Q+1;
+    preprocessingQ(x,m,F);
+    for(i=0; i<m; i++) y[n+i]=x[i];
+    END_PREPROCESSING
+
+    BEGIN_SEARCHING
+    /* Searching */
+    count = 0;
+    if( !memcmp(x,y,plen) ) count++;
+    j=m;
+    while (j < n) {
+        h = HASH(j);
+        i = j-m+1;
+        while((test=F[h]) && j>i+Q-1) {
+            j-=Q;
+            h = (h<<16) + HASH(j);
+        }
+        if(j==i+Q-1 && test) {
+            k=0;
+            while(k<plen && x[k]==y[i+k]) k++;
+            if(k==plen && i<=n-plen)
+                count++;
+        }
+        j+=m-Q+1;
+    }
+    END_SEARCHING
+    return count;
+}


### PR DESCRIPTION
  * Search algorithm identical
  * Pre-processing works on q-grams rather than bytes.
    Does not set bits for hash values that cannot match,
    so reduces false positives in search phase.
  * Helps particularly on lower alphabet and shorter patterns.
  * Longer, higher alphabet patterns it is still often
    a bit faster but the gap is narrow.