### PR TITLE
FIX: getc returns an int, and EOF is an int value.

### DIFF
--- a/source/smart.c
+++ b/source/smart.c
@@ -112,7 +112,7 @@ int getText(unsigned char *T, char *path, int FREQ[SIGMA], int TSIZE) {
 				printf("\tLoading the file %s\n",filename);
 				FILE *input;
 				if( (input = fopen(filename, "r")) )  {
-					char d;
+					int d;
 					while(i<TSIZE && (d=getc(input))!=EOF ) T[i++]=d;
 					fclose(input);
 				}


### PR DESCRIPTION
  * When d is an unsigned char, it does not process EOF properly.
  * Read the midimusic data, and only a very small text buffer will be created, as only a tiny part of each file is read.
  * make d an int, so EOF is handled properly.